### PR TITLE
修复：移除注册接口中打印敏感信息的调试语句

### DIFF
--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -250,9 +250,7 @@ async def register(request: Request, name: str = Form(...), password: str = Form
             detail=error_msg
         )
     
-    print(name, email)
     form_data = await request.form()
-    print(form_data.get("phone"))
     # 检查手机号是否已注册
     existing_user = db.query(Users).filter(Users.phone == phone).first()
     existing_register = db.query(Register).filter(Register.phone == phone).first()


### PR DESCRIPTION
## 修复内容

注册接口 `/api/users/register` 中残留了 `print(name, email)` 和 `print(form_data.get("phone"))` 调试语句，会将用户姓名、邮箱、手机号打印到服务器日志中，存在敏感信息泄露风险。

## 修改内容
- `app/routers/users.py`: 移除 register 函数中的两行 print 语句

## 测试
- 注册流程正常
- 不再泄露用户信息到日志