### PR TITLE
修复：移除docker-compose中已废弃的version字段

### DIFF
--- a/tm-backend/docker-compose.yml
+++ b/tm-backend/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   fastapi_app:
     build: .


### PR DESCRIPTION
## 修复内容

`docker-compose.yml` 中使用了 `version: "3.8"` 字段。Docker Compose V2 已不再需要此字段，且会产生弃用警告。

## 修改内容
- `tm-backend/docker-compose.yml`: 移除 `version: "3.8"` 行

## 测试
- docker compose config 验证配置正常
- 不再产生弃用警告