### PR TITLE
修复：管理员密码重置接口添加权限验证

### DIFF
--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -362,7 +362,7 @@ async def handle_changepass(newpass: str = Form(...), name: str = Form(...), use
     return {"code": 200, "message":"OK"}
 
 @router.post("/reset_pass")
-async def reset_pass(phone: str = Form(...), password: str = Form(...), db: Session = Depends(get_db)):
+async def reset_pass(phone: str = Form(...), password: str = Form(...), user: TokenModel = Depends(require_admin), db: Session = Depends(get_db)):
     # 验证密码强度
     is_valid, error_msg = validate_password_strength(password)
     if not is_valid:
@@ -492,7 +492,7 @@ async def reset_list():
     return parsed_list
 
 @router.post("/handle_reset_pass")
-async def handle_reset_pass(action: str = Form(...), id: int = Form(...), db: Session = Depends(get_db)):
+async def handle_reset_pass(action: str = Form(...), id: int = Form(...), user: TokenModel = Depends(require_admin), db: Session = Depends(get_db)):
     reset_file_path = "static/am/reset_pass.txt"
     reset_list = []
     

--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -365,7 +365,7 @@ async def handle_changepass(newpass: str = Form(...), name: str = Form(...), use
     return {"code": 200, "message":"OK"}
 
 @router.post("/reset_pass")
-async def reset_pass(phone: str = Form(...), password: str = Form(...), db: Session = Depends(get_db)):
+async def reset_pass(phone: str = Form(...), password: str = Form(...), user: TokenModel = Depends(require_admin), db: Session = Depends(get_db)):
     # 验证密码强度
     is_valid, error_msg = validate_password_strength(password)
     if not is_valid:
@@ -495,7 +495,7 @@ async def reset_list():
     return parsed_list
 
 @router.post("/handle_reset_pass")
-async def handle_reset_pass(action: str = Form(...), id: int = Form(...), db: Session = Depends(get_db)):
+async def handle_reset_pass(action: str = Form(...), id: int = Form(...), user: TokenModel = Depends(require_admin), db: Session = Depends(get_db)):
     reset_file_path = "static/am/reset_pass.txt"
     reset_list = []
     


### PR DESCRIPTION
## 修复内容

`/api/users/reset_pass` 和 `/api/users/handle_reset_pass` 两个管理员接口缺少权限验证，任何未登录用户均可直接调用。

- `reset_pass`: 可通过手机号直接重置任意用户密码
- `handle_reset_pass`: 可删除或重置任意用户的密码

## 修改内容
- `app/routers/users.py`: 为两个接口添加 `user: TokenModel = Depends(require_admin)` 参数，要求管理员权限

## 测试
- 管理员用户可正常使用密码重置功能
- 未登录或非管理员用户调用返回401/403