### PR TITLE
修复：移除注册接口及请求拦截器中的调试输出语句

### DIFF
--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -250,9 +250,6 @@ async def register(request: Request, name: str = Form(...), password: str = Form
             detail=error_msg
         )
     
-    print(name, email)
-    form_data = await request.form()
-    print(form_data.get("phone"))
     # 检查手机号是否已注册
     existing_user = db.query(Users).filter(Users.phone == phone).first()
     existing_register = db.query(Register).filter(Register.phone == phone).first()

--- a/tm-frontend/src/request/base.ts
+++ b/tm-frontend/src/request/base.ts
@@ -62,10 +62,8 @@ instance.interceptors.response.use(
         // 处理401错误 - token过期
         if (data?.detail?.code === 5000 && config && !config.url?.includes('/refresh')) {
             loginstate.atoken = ''
-            console.log("准备刷新token");
             try {
                 const res = await refreshToken();
-                console.log(res);
                 if (res && res.id > 0) {
                     return instance(config);
                 } else {

--- a/tm-frontend/src/views/Study.vue
+++ b/tm-frontend/src/views/Study.vue
@@ -290,7 +290,6 @@ const submitReport = async () => {
 const beforeUnload = () => {
   if (studyTimer.value > 60) {
     // 实际项目中这里可以发送请求
-    console.log('学习时长:', studyTimer.value)
   }
 }
 


### PR DESCRIPTION
## 修改说明

移除以下调试输出语句，消除生产环境中的安全风险和冗余日志：

1. **后端 - 用户注册接口**（）
   - 移除  接口中调试用的  和 
   - 移除冗余的  调用（参数已通过 FastAPI 依赖注入获取）

2. **前端 - 请求拦截器**（）
   - 移除 token 刷新逻辑中的调试日志  和 

3. **前端 - 学习页面**（）
   - 移除 beforeUnload 钩子中的调试日志 

## 修改范围
- ：3 行
- ：2 行
- ：1 行

共计 3 文件，删除 6 行。

## 验证
- 后端：Python 语法检查通过（）
- 前端：修改为纯删除操作，不涉及逻辑变更，无兼容性风险