### PR TITLE
修复：Docker不可用时subprocess回退传参错误

### DIFF
--- a/tm-backend/app/services/python_executor.py
+++ b/tm-backend/app/services/python_executor.py
@@ -174,29 +174,26 @@ e = math.e
                 'exitCode': -1
             }
         except Exception as e:
-            # Docker 不可用，回退到 subprocess 方式（注意：full_code 已在上面构造）
-            return self._execute_with_subprocess(code, timeout)
+            # Docker 不可用，回退到 subprocess 方式
+            return self._execute_with_subprocess(full_code, timeout)
 
     def _execute_with_subprocess(self, code: str, timeout: int) -> Dict[str, Any]:
         """
         使用 subprocess 执行 Python 代码（备用方案）
 
         Args:
-            code: Python 代码
+            code: Python 代码（已含预导入模块）
             timeout: 超时时间（秒）
 
         Returns:
             dict: { stdout, stderr, exitCode }
         """
-        # 在用户代码前添加预导入模块
-        full_code = self.PREIMPORTED_MODULES + '\n' + code
-
         python_cmd = self._get_python_command()
 
         try:
             # 使用 subprocess 运行 Python
             result = subprocess.run(
-                [python_cmd, '-c', full_code],
+                [python_cmd, '-c', code],
                 capture_output=True,
                 text=True,
                 timeout=timeout,


### PR DESCRIPTION
## 修改内容

`python_executor.py` 中 Docker 环境不可用时，`execute` 方法的 `except` 分支将原始 `code` 传递给 `_execute_with_subprocess`，但该方法内部会再次拼接 `PREIMPORTED_MODULES`。而 `ImportError` 分支传入的是已拼接的 `full_code`，两处调用行为不一致。

## 修改方案

- `execute` 方法的 `except Exception` 分支改为传入 `full_code`
- `_execute_with_subprocess` 移除内部重复的 `PREIMPORTED_MODULES` 拼接，直接使用传入的代码
- 统一两处调用 `_execute_with_subprocess` 的行为

## 验证

- `py_compile` 语法检查通过
- `ruff check` 无新增违规
