### PR TITLE
移除：删除未使用的import requests

### DIFF
--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from app.dependencies import check_jwt_token, get_db, verify_password, get_password_hash, require_admin
 from app.config import settings
 from jose import jwt
-import requests
 import os
 import json
 import glob

--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -6,7 +6,6 @@ logger = logging.getLogger(__name__)
 from app.dependencies import check_jwt_token, get_db, verify_password, get_password_hash, require_admin
 from app.config import settings
 from jose import jwt
-import requests
 import os
 import json
 import glob


### PR DESCRIPTION
## 修改内容

`users.py` 中导入了 `requests` 模块，但文件内没有任何代码使用该模块（相关调用已在早期被注释掉）。

## 修改方案

删除第 6 行 `import requests`。

## 验证

- `py_compile` 语法检查通过
- 全文件搜索确认无任何对 `requests` 的引用
