### PR TITLE
修复：上传文件使用实际扩展名而非固定.jpg

### DIFF
--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -621,12 +621,12 @@ async def save_profile(request: Request, user: TokenModel = Depends(check_jwt_to
         user_id = form.get("id") or str(user.id)
         serial = 4
         for i in range(0, 5):
-            pattern = str(user_id) + "_" + str(i) + "*.jpg"
+            pattern = str(user_id) + "_" + str(i) + "*" + file_extension
             if not glob.glob(os.path.join(save_base_dir, pattern)):
                 serial = i
                 break
         
-        filename = str(user_id) + "_" + str(serial) + "_" + timestamp + ".jpg"
+        filename = str(user_id) + "_" + str(serial) + "_" + timestamp + file_extension
         file_path = os.path.join(save_base_dir, filename)
         
         # 使用上下文管理器确保文件正确关闭

--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -624,12 +624,12 @@ async def save_profile(request: Request, user: TokenModel = Depends(check_jwt_to
         user_id = form.get("id") or str(user.id)
         serial = 4
         for i in range(0, 5):
-            pattern = str(user_id) + "_" + str(i) + "*.jpg"
+            pattern = str(user_id) + "_" + str(i) + "*" + file_extension
             if not glob.glob(os.path.join(save_base_dir, pattern)):
                 serial = i
                 break
         
-        filename = str(user_id) + "_" + str(serial) + "_" + timestamp + ".jpg"
+        filename = str(user_id) + "_" + str(serial) + "_" + timestamp + file_extension
         file_path = os.path.join(save_base_dir, filename)
         
         # 使用上下文管理器确保文件正确关闭


### PR DESCRIPTION
## 修改内容

头像上传接口中，文件类型已通过白名单校验（`.jpg/.jpeg/.png/.gif`），但保存时文件名始终使用 `.jpg` 扩展名。导致 PNG/GIF 文件被保存为 `.jpg`，文件内容与扩展名不匹配。

## 修改方案

将文件名拼接中的硬编码 `.jpg` 改为使用已校验的 `file_extension` 变量：
- `users.py` 第 624 行：glob 匹配模式使用 `file_extension`
- `users.py` 第 629 行：文件名使用 `file_extension`

## 验证

- `py_compile` 语法检查通过
- `file_extension` 已在上游通过白名单校验，值安全可靠
