### PR TITLE
清理：移除users.py中注释掉的废弃代码

### DIFF
--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -18,7 +18,6 @@ from app.database import engine
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 import smtplib
-# from app.core.config import settings
 Base.metadata.create_all(bind=engine)
 
 router = APIRouter(
@@ -184,15 +183,6 @@ def reset_password(
     
     return {"message": "密码重置成功"}
 
-# import httpx 
-# async def login_flask(id,name,phone,role):
-#     url = 'http://127.0.0.1:8008/v1/auth/login_api'
-#     headers = {"content-type": "application/x-www-form-urlencoded"} 
-#     data = {"id": id, "name": name, "phone":phone, "role":role}
-#     async with httpx.AsyncClient() as client:  
-#         res = await client.post(url, data=data, headers=headers)  
-#     return res.text
-
 
 
 # 使用表单格式参数需要安装模块：python-multipart
@@ -218,8 +208,6 @@ async def login_for_access_token(phone: str = Form(...), password: str = Form(..
     )
     user.atoken = access_token
     user.rtoken = refresh_token
-    #rtn = await login_flask(user.id,user.username,user.phone,user.role)
-    #print(rtn)
     return user
 
 @router.get("/refresh", response_model=TokenModel)

--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -21,7 +21,6 @@ from app.database import engine
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 import smtplib
-# from app.core.config import settings
 Base.metadata.create_all(bind=engine)
 
 router = APIRouter(
@@ -187,15 +186,6 @@ def reset_password(
     
     return {"message": "密码重置成功"}
 
-# import httpx 
-# async def login_flask(id,name,phone,role):
-#     url = 'http://127.0.0.1:8008/v1/auth/login_api'
-#     headers = {"content-type": "application/x-www-form-urlencoded"} 
-#     data = {"id": id, "name": name, "phone":phone, "role":role}
-#     async with httpx.AsyncClient() as client:  
-#         res = await client.post(url, data=data, headers=headers)  
-#     return res.text
-
 
 
 # 使用表单格式参数需要安装模块：python-multipart
@@ -221,8 +211,6 @@ async def login_for_access_token(phone: str = Form(...), password: str = Form(..
     )
     user.atoken = access_token
     user.rtoken = refresh_token
-    #rtn = await login_flask(user.id,user.username,user.phone,user.role)
-    #print(rtn)
     return user
 
 @router.get("/refresh", response_model=TokenModel)


### PR DESCRIPTION
## 修改内容

`users.py` 中包含多处已注释掉的废弃代码：
- 第 21 行：重复导入 `settings`（已在第 4 行导入）
- 第 186-193 行：注释掉的 `login_flask` 函数（使用已移除的 `httpx` 模块）
- 第 211-212 行：注释掉的 `login_flask` 调用

## 修改方案

删除上述已注释掉且不再使用的代码。不影响任何现有功能。

## 验证

- `py_compile` 语法检查通过
