### PR TITLE
修复：statistics.py中任务统计IndexError异常

### DIFF
--- a/tm-backend/app/routers/statistics.py
+++ b/tm-backend/app/routers/statistics.py
@@ -527,8 +527,8 @@ async def get_user_detail_analysis(
                 other_tasks.append(task)
 
     # 计算平均完成时间
-    planned_hours = sum(len(t) > 4 and t[4] or 0 for t in planned_tasks if isinstance(t[4], (int, float))) / 60
-    actual_hours = sum(len(t) > 7 and t[7] or 0 for t in finished_tasks if isinstance(t[7], (int, float))) / 60
+    planned_hours = sum(t[4] or 0 for t in planned_tasks if len(t) > 4 and isinstance(t[4], (int, float))) / 60
+    actual_hours = sum(t[7] or 0 for t in finished_tasks if len(t) > 7 and isinstance(t[7], (int, float))) / 60
 
     return {
         "code": 200,

--- a/tm-backend/app/routers/statistics.py
+++ b/tm-backend/app/routers/statistics.py
@@ -530,8 +530,8 @@ async def get_user_detail_analysis(
                 other_tasks.append(task)
 
     # 计算平均完成时间
-    planned_hours = sum(len(t) > 4 and t[4] or 0 for t in planned_tasks if isinstance(t[4], (int, float))) / 60
-    actual_hours = sum(len(t) > 7 and t[7] or 0 for t in finished_tasks if isinstance(t[7], (int, float))) / 60
+    planned_hours = sum(t[4] or 0 for t in planned_tasks if len(t) > 4 and isinstance(t[4], (int, float))) / 60
+    actual_hours = sum(t[7] or 0 for t in finished_tasks if len(t) > 7 and isinstance(t[7], (int, float))) / 60
 
     return {
         "code": 200,


### PR DESCRIPTION
## 修复内容

`statistics.py` 中 `/personal/detail/{user_id}` 端点的任务统计逻辑存在 IndexError 隐患。

## 问题分析

第 530-531 行的 generator expression 中，`if isinstance(t[4], (int, float))` 过滤条件会在 `len(t)` 检查之前对 `t[4]` 求值。当任务列表中包含长度不足的元素（如 `len(task) <= 4`）时，`t[4]` 会触发 IndexError，导致接口返回 500。

```python
# 修复前（会 IndexError）
sum(len(t) > 4 and t[4] or 0 for t in planned_tasks if isinstance(t[4], (int, float)))

# 修复后（先检查长度再访问索引）
sum(t[4] or 0 for t in planned_tasks if len(t) > 4 and isinstance(t[4], (int, float)))
```

将 `len(t) > N` 的长度检查移至 filter 条件的首位，利用 Python 短路求值确保在访问 `t[N]` 前已确认索引安全。

## 验证

- py_compile 语法检查通过
- 本地模拟测试：短列表数据不再触发 IndexError
- 原有正常数据计算结果不变
