### PR TITLE
修复：inno.py中ast.literal_eval添加异常容错处理

### DIFF
--- a/tm-backend/app/routers/inno.py
+++ b/tm-backend/app/routers/inno.py
@@ -25,11 +25,23 @@ async def get_tm(user_id:int):
     if os.path.exists(f"static/tm/t{userid}.txt"):
         with open(f"static/tm/t{userid}.txt", "r", encoding="utf-8") as f:
             pr=f.readlines()
-    pr = [ast.literal_eval(x) for x in pr]
+    parsed_pr = []
+    for x in pr:
+        try:
+            parsed_pr.append(ast.literal_eval(x))
+        except (ValueError, SyntaxError):
+            continue
+    pr = parsed_pr
     if os.path.exists(f"static/tm/f{userid}.txt"):
         with open(f"static/tm/f{userid}.txt", "r", encoding="utf-8") as f:
             fn=f.readlines()
-    fn = [ast.literal_eval(x) for x in fn]
+    parsed_fn = []
+    for x in fn:
+        try:
+            parsed_fn.append(ast.literal_eval(x))
+        except (ValueError, SyntaxError):
+            continue
+    fn = parsed_fn
     fn.reverse()
     return {"pr":pr, "fn":fn}
 
@@ -40,7 +52,13 @@ async def get_pr(user_id:int):
     if os.path.exists(f"static/tm/t{userid}.txt"):
         with open(f"static/tm/t{userid}.txt", "r", encoding="utf-8") as f:
             pr=f.readlines()
-    pr = [ast.literal_eval(x) for x in pr]
+    parsed_pr = []
+    for x in pr:
+        try:
+            parsed_pr.append(ast.literal_eval(x))
+        except (ValueError, SyntaxError):
+            continue
+    pr = parsed_pr
     return pr
 
 @inno.put('/save_pr/{user_id}')
@@ -107,7 +125,11 @@ async def add_study_time(request: Request, user_id:int):
         existing_pr = []
         if os.path.exists(f"static/tm/t{userid}.txt"):
             with open(f"static/tm/t{userid}.txt", "r", encoding="utf-8") as f:
-                existing_pr = [ast.literal_eval(x) for x in f.readlines()]
+                for x in f.readlines():
+                    try:
+                        existing_pr.append(ast.literal_eval(x))
+                    except (ValueError, SyntaxError):
+                        continue
 
         # 追加新的学习记录
         for line in tasklist:

--- a/tm-backend/app/routers/inno.py
+++ b/tm-backend/app/routers/inno.py
@@ -28,11 +28,23 @@ async def get_tm(user_id:int):
     if os.path.exists(f"static/tm/t{userid}.txt"):
         with open(f"static/tm/t{userid}.txt", "r", encoding="utf-8") as f:
             pr=f.readlines()
-    pr = [ast.literal_eval(x) for x in pr]
+    parsed_pr = []
+    for x in pr:
+        try:
+            parsed_pr.append(ast.literal_eval(x))
+        except (ValueError, SyntaxError):
+            continue
+    pr = parsed_pr
     if os.path.exists(f"static/tm/f{userid}.txt"):
         with open(f"static/tm/f{userid}.txt", "r", encoding="utf-8") as f:
             fn=f.readlines()
-    fn = [ast.literal_eval(x) for x in fn]
+    parsed_fn = []
+    for x in fn:
+        try:
+            parsed_fn.append(ast.literal_eval(x))
+        except (ValueError, SyntaxError):
+            continue
+    fn = parsed_fn
     fn.reverse()
     return {"pr":pr, "fn":fn}
 
@@ -43,7 +55,13 @@ async def get_pr(user_id:int):
     if os.path.exists(f"static/tm/t{userid}.txt"):
         with open(f"static/tm/t{userid}.txt", "r", encoding="utf-8") as f:
             pr=f.readlines()
-    pr = [ast.literal_eval(x) for x in pr]
+    parsed_pr = []
+    for x in pr:
+        try:
+            parsed_pr.append(ast.literal_eval(x))
+        except (ValueError, SyntaxError):
+            continue
+    pr = parsed_pr
     return pr
 
 @inno.put('/save_pr/{user_id}')
@@ -110,7 +128,11 @@ async def add_study_time(request: Request, user_id:int):
         existing_pr = []
         if os.path.exists(f"static/tm/t{userid}.txt"):
             with open(f"static/tm/t{userid}.txt", "r", encoding="utf-8") as f:
-                existing_pr = [ast.literal_eval(x) for x in f.readlines()]
+                for x in f.readlines():
+                    try:
+                        existing_pr.append(ast.literal_eval(x))
+                    except (ValueError, SyntaxError):
+                        continue
 
         # 追加新的学习记录
         for line in tasklist:


### PR DESCRIPTION
## 修改内容

为 `inno.py` 中所有 `ast.literal_eval` 调用添加异常容错处理。

## 问题描述

`get_tm`、`get_pr`、`add_study_time` 等端点直接使用列表推导调用 `ast.literal_eval` 解析文件内容，未做异常处理。当文件中存在格式错误的数据行时，整个接口会抛出 500 错误。

## 修复方案

将所有 `ast.literal_eval` 调用包裹在 `try/except (ValueError, SyntaxError)` 中，跳过无法解析的行而非中断整个请求。

## 验证

- 语法检查通过
- 所有 5 处 literal_eval 调用均已有异常处理