### PR TITLE
修复：密码重置邮件中的链接补全http协议前缀

### DIFF
--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -82,7 +82,7 @@ def send_reset_password_email(email: str, reset_token: str):
     msg['Subject'] = '密码重置'
 
     # 邮件正文
-    reset_link = f"{settings.HOST}:{settings.PORT}/reset-password?token={reset_token}"
+    reset_link = f"http://{settings.HOST}:{settings.PORT}/reset-password?token={reset_token}"
     body = f"""
     您好,
 

--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -85,7 +85,7 @@ def send_reset_password_email(email: str, reset_token: str):
     msg['Subject'] = '密码重置'
 
     # 邮件正文
-    reset_link = f"{settings.HOST}:{settings.PORT}/reset-password?token={reset_token}"
+    reset_link = f"http://{settings.HOST}:{settings.PORT}/reset-password?token={reset_token}"
     body = f"""
     您好,
 


### PR DESCRIPTION
## 修改内容

补全密码重置邮件中链接缺失的 `http://` 协议前缀。

## 问题描述

`users.py` 第 85 行生成的密码重置链接格式为 `{HOST}:{PORT}/reset-password?token=...`，缺少协议前缀，在邮件客户端中无法作为有效链接点击。

## 修复方案

补全为 `http://{HOST}:{PORT}/reset-password?token=...`。

## 验证

- 语法检查通过