### PR TITLE
优化：seed.py和check_password.py使用配置文件中的数据库路径

### DIFF
--- a/tm-backend/check_password.py
+++ b/tm-backend/check_password.py
@@ -1,9 +1,10 @@
 from passlib.context import CryptContext
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 from app.core.models.users import Users
+from app.config import settings
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-engine = create_engine("sqlite:///mydatabase.db")
+engine = create_engine(settings.SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 db = SessionLocal()
 phone = "15812345678"

--- a/tm-backend/seed.py
+++ b/tm-backend/seed.py
@@ -1,5 +1,6 @@
 from app.core.models.users import Users
 from app.dependencies import get_password_hash
+from app.config import settings
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from datetime import datetime
@@ -12,7 +13,7 @@ def create_directory(directory):
 create_directory("static")
 create_directory("static/profiles")
 create_directory("static/tm")
-engine = create_engine("sqlite:///mydatabase.db")
+engine = create_engine(settings.SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 db = SessionLocal()
 new_user = Users(


### PR DESCRIPTION
## 修改内容

`seed.py` 和 `check_password.py` 中硬编码的数据库路径改为使用 `app/config.py` 中的统一配置。

## 问题描述

两个文件中直接使用 `create_engine("sqlite:///mydatabase.db")` 硬编码数据库路径，当配置文件中修改数据库地址时这两个脚本不会同步更新。

## 修复方案

改为 `create_engine(settings.SQLALCHEMY_DATABASE_URL)`，与 `database.py` 保持一致。

## 验证

- 语法检查通过