### PR TITLE
优化：Pydantic Schema字段类型注解改用Optional

### DIFF
--- a/tm-backend/app/core/schemas/users.py
+++ b/tm-backend/app/core/schemas/users.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, EmailStr
 
 class UserBase(BaseModel):
     id: Optional[int] = False
-    username: str = None
+    username: Optional[str] = None
     # pip install pydantic[email] 使用email验证的时候需要增加这个库
     email: Optional[EmailStr] = None
     role: Optional[str] = 'user'
@@ -12,12 +12,12 @@ class UserBase(BaseModel):
         from_attributes = True
 
 class TokenModel(UserBase):
-    atoken: str = None
-    rtoken: str = None
+    atoken: Optional[str] = None
+    rtoken: Optional[str] = None
 
 class LoginModel(BaseModel):
-    phone: str = None
-    password: str = None
+    phone: Optional[str] = None
+    password: Optional[str] = None
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
## 修改内容

Pydantic Schema 中 `str = None` 类型的字段统一改为 `Optional[str] = None`。

## 问题描述

`users.py` Schema 中多个字段声明为 `str = None`，类型注解与默认值不匹配，在 Pydantic 严格模式或 mypy 检查下会报类型错误。

涉及字段：
- `UserBase.username`
- `TokenModel.atoken`, `TokenModel.rtoken`
- `LoginModel.phone`, `LoginModel.password`

## 修复方案

统一改为 `Optional[str] = None`，与同文件其他字段的风格保持一致。

## 验证

- 语法检查通过