### PR TITLE
修复：SQLAlchemy declarative_base 使用已弃用导入路径

### DIFF
--- a/tm-backend/app/database.py
+++ b/tm-backend/app/database.py
@@ -1,5 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import sessionmaker
 from .config import settings
 


### PR DESCRIPTION
## 修改说明

`sqlalchemy.ext.declarative` 在 SQLAlchemy 2.0 中已弃用，`declarative_base` 已迁移到 `sqlalchemy.orm`。

### 修改内容

- **文件**: `tm-backend/app/database.py`
- 将 `from sqlalchemy.ext.declarative import declarative_base` 改为 `from sqlalchemy.orm import declarative_base`

### 验证

- `python3 -m py_compile app/database.py` 通过
- 功能等价，仅迁移导入路径
