### PR TITLE
修复：get_db 数据库会话异常时缺少回滚操作

### DIFF
--- a/tm-backend/app/dependencies.py
+++ b/tm-backend/app/dependencies.py
@@ -18,6 +18,9 @@ def get_db():
     db = SessionLocal()
     try:
         yield db
+    except Exception:
+        db.rollback()
+        raise
     finally:
         db.close()
 


### PR DESCRIPTION
## 修改说明

FastAPI 数据库会话依赖注入函数 `get_db()` 在请求处理发生异常时，缺少 `rollback()` 操作，可能导致会话状态不干净。

### 修改内容

- **文件**: `tm-backend/app/dependencies.py`
- 在 `try/finally` 之间增加 `except Exception` 块，捕获异常时执行 `db.rollback()` 后重新抛出

### 验证

- `python3 -m py_compile app/dependencies.py` 通过
- 遵循 FastAPI 官方推荐的数据库会话管理模式
