### PR TITLE
fix: remove redundant JWT auth dependency on admin endpoints

### DIFF
--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -280,7 +280,7 @@ async def register(request: Request, name: str = Form(...), password: str = Form
         )
     return {"code": 200, "message":"OK"}
 
-@router.get("/fetch_registrations", dependencies=[Depends(check_jwt_token)])
+@router.get("/fetch_registrations")
 async def fetch_registrations(user: TokenModel = Depends(require_admin), db: Session = Depends(get_db)):
     result_proxy = db.query(Register).all()
     all_q_registrations = [{"id":row.id, "name":row.name, "phone":row.phone, "email":row.email, "notes":row.notes, "register_time":row.register_time} for row in result_proxy]
@@ -745,7 +745,7 @@ async def submit_profile(info: str = Form(...),
     return {"code": 200, "message":"OK"}
 
 
-@router.get("/fetch_all_users", dependencies=[Depends(check_jwt_token)])
+@router.get("/fetch_all_users")
 async def fetch_all_users(user: TokenModel = Depends(require_admin), db: Session = Depends(get_db)):
     """
     获取所有用户列表

--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -283,7 +283,7 @@ async def register(request: Request, name: str = Form(...), password: str = Form
         )
     return {"code": 200, "message":"OK"}
 
-@router.get("/fetch_registrations", dependencies=[Depends(check_jwt_token)])
+@router.get("/fetch_registrations")
 async def fetch_registrations(user: TokenModel = Depends(require_admin), db: Session = Depends(get_db)):
     result_proxy = db.query(Register).all()
     all_q_registrations = [{"id":row.id, "name":row.name, "phone":row.phone, "email":row.email, "notes":row.notes, "register_time":row.register_time} for row in result_proxy]
@@ -748,7 +748,7 @@ async def submit_profile(info: str = Form(...),
     return {"code": 200, "message":"OK"}
 
 
-@router.get("/fetch_all_users", dependencies=[Depends(check_jwt_token)])
+@router.get("/fetch_all_users")
 async def fetch_all_users(user: TokenModel = Depends(require_admin), db: Session = Depends(get_db)):
     """
     获取所有用户列表


### PR DESCRIPTION
## 修改说明

`fetch_registrations` 和 `fetch_all_users` 两个管理员接口存在双重认证依赖声明。

### 问题

这两个路由同时声明了：
1. 装饰器参数 `dependencies=[Depends(check_jwt_token)]`
2. 函数参数 `user = Depends(require_admin)`

而 `require_admin` 内部已经调用了 `check_jwt_token`，装饰器级别的依赖声明是冗余的。

### 修改内容

- **文件**: `tm-backend/app/routers/users.py`
- 第283行：`fetch_registrations` 移除 `dependencies=[Depends(check_jwt_token)]`
- 第748行：`fetch_all_users` 移除 `dependencies=[Depends(check_jwt_token)]`

### 验证

- `python3 -m py_compile app/routers/users.py` 通过
- 认证逻辑不变，`require_admin` 已包含 JWT 验证
