### PR TITLE
fix: remove duplicate datetime imports in statistics.py

### DIFF
--- a/tm-backend/app/routers/statistics.py
+++ b/tm-backend/app/routers/statistics.py
@@ -86,7 +86,6 @@ async def get_personal_trend(
 ):
     """获取个人学习时长趋势"""
     from app.core.models.users import Users
-    from datetime import datetime, timedelta
 
     end_date = datetime.now()
     start_date = end_date - timedelta(days=days)
@@ -260,7 +259,6 @@ async def get_growth_trend(
 ):
     """获取用户增长趋势"""
     from app.core.models.users import Users
-    from datetime import datetime, timedelta
     from sqlalchemy import cast, Date
 
     end_date = datetime.now()

--- a/tm-backend/app/routers/statistics.py
+++ b/tm-backend/app/routers/statistics.py
@@ -89,7 +89,6 @@ async def get_personal_trend(
 ):
     """获取个人学习时长趋势"""
     from app.core.models.users import Users
-    from datetime import datetime, timedelta
 
     end_date = datetime.now()
     start_date = end_date - timedelta(days=days)
@@ -263,7 +262,6 @@ async def get_growth_trend(
 ):
     """获取用户增长趋势"""
     from app.core.models.users import Users
-    from datetime import datetime, timedelta
     from sqlalchemy import cast, Date
 
     end_date = datetime.now()


### PR DESCRIPTION
## 修改说明

`statistics.py` 文件顶部第4行已有 `from datetime import datetime, timedelta`，但在 `get_personal_trend`（第89行）和 `get_user_growth_trend`（第263行）两个函数内又重复导入了相同的模块。

### 修改内容

- **文件**: `tm-backend/app/routers/statistics.py`
- 删除第89行函数内的 `from datetime import datetime, timedelta`
- 删除第263行函数内的 `from datetime import datetime, timedelta`

### 验证

- `python3 -m py_compile app/routers/statistics.py` 通过
- 顶层导入已覆盖全部使用场景
