### PR TITLE
fix: change SMTP default port to 587 to match STARTTLS usage

### DIFF
--- a/tm-backend/app/config.py
+++ b/tm-backend/app/config.py
@@ -10,7 +10,7 @@ class Settings(BaseSettings):
     SQLALCHEMY_DATABASE_URL:str
     # SMTP 邮件配置（可选，配置后可发送密码重置邮件）
     SMTP_HOST:str = "smtp.163.com"
-    SMTP_PORT:int = 465
+    SMTP_PORT:int = 587
     SMTP_USER:str = ""
     SMTP_PASSWORD:str = ""
     # 兼容旧配置名


### PR DESCRIPTION
## 修改说明

SMTP 默认端口与连接方式不匹配。

### 问题

`config.py` 中 `SMTP_PORT` 默认值为 `465`（SMTP over SSL 标准端口），但 `users.py` 中邮件发送使用的是 `smtplib.SMTP` + `starttls()` 方式连接，该方式对应的标准端口为 `587`。

端口 465 应配合 `smtplib.SMTP_SSL` 使用，与当前代码不匹配。

### 修改内容

- **文件**: `tm-backend/app/config.py`
- 将 `SMTP_PORT` 默认值从 `465` 改为 `587`，与代码中 `SMTP + starttls()` 连接方式一致

### 验证

- `python3 -m py_compile app/config.py` 通过
- 如有 `.env` 文件已配置 `SMTP_PORT=465`，则不受此默认值影响
