### PR TITLE
清理：移除未使用的import（WSGIMiddleware、config、Sequence、shlex）

### DIFF
--- a/tm-backend/app/core/models/users.py
+++ b/tm-backend/app/core/models/users.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, Float, VARCHAR, Sequence, DateTime
+from sqlalchemy import Column, Integer, Float, VARCHAR, DateTime
 from app.database import Base
 
 class Users(Base):

--- a/tm-backend/app/dependencies.py
+++ b/tm-backend/app/dependencies.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from . import config
 from .database import SessionLocal
 from typing import Optional
 from fastapi import Header, HTTPException, status, Depends

--- a/tm-backend/app/services/python_executor.py
+++ b/tm-backend/app/services/python_executor.py
@@ -8,7 +8,6 @@ import sys
 import platform
 from typing import Dict, Any
 import subprocess
-import shlex
 
 
 class PythonExecutor:

--- a/tm-backend/main.py
+++ b/tm-backend/main.py
@@ -2,7 +2,6 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.middleware.wsgi import WSGIMiddleware
 
 from app.routers import users
 from app.routers import inno

--- a/tm-backend/main.py
+++ b/tm-backend/main.py
@@ -3,7 +3,6 @@ import logging
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.middleware.wsgi import WSGIMiddleware
 
 from app.routers import users
 from app.routers import inno


### PR DESCRIPTION
移除以下未使用的 import：
- `main.py`: `WSGIMiddleware`（未被引用）
- `app/dependencies.py`: `from . import config`（实际使用 `from .config import settings`）
- `app/core/models/users.py`: `Sequence`（模型中未使用）
- `app/services/python_executor.py`: `shlex`（代码中未调用）

已通过 `py_compile` 验证，无语法错误。