### PR TITLE
修复：用户列表排序参数添加白名单校验，防止任意字段访问

### DIFF
--- a/tm-backend/app/routers/statistics.py
+++ b/tm-backend/app/routers/statistics.py
@@ -332,7 +332,10 @@ async def get_users_learning_list(
     if bumen:
         query = query.filter(Users.bumen == bumen)
 
-    # 排序
+    # 排序（仅允许白名单字段）
+    allowed_sort_fields = {"learn_hour", "create_hour", "shuzhi", "id", "username"}
+    if sort_by not in allowed_sort_fields:
+        sort_by = "learn_hour"
     sort_column = getattr(Users, sort_by, Users.learn_hour)
     if sort_order == "desc":
         query = query.order_by(desc(sort_column))

--- a/tm-backend/app/routers/statistics.py
+++ b/tm-backend/app/routers/statistics.py
@@ -335,7 +335,10 @@ async def get_users_learning_list(
     if bumen:
         query = query.filter(Users.bumen == bumen)
 
-    # 排序
+    # 排序（仅允许白名单字段）
+    allowed_sort_fields = {"learn_hour", "create_hour", "shuzhi", "id", "username"}
+    if sort_by not in allowed_sort_fields:
+        sort_by = "learn_hour"
     sort_column = getattr(Users, sort_by, Users.learn_hour)
     if sort_order == "desc":
         query = query.order_by(desc(sort_column))


### PR DESCRIPTION
`/api/statistics/global/users-list` 接口的 `sort_by` 参数直接传入 `getattr(Users, sort_by, ...)`，未做字段白名单校验。

攻击者可通过传入 `password` 等敏感字段名进行排序，可能泄露用户密码哈希的统计信息。

修复方式：添加白名单校验，仅允许 `learn_hour`、`create_hour`、`shuzhi`、`id`、`username` 五个安全字段作为排序依据。

已通过 `py_compile` 验证。