### PR TITLE
修复：check_password.py用户不存在时None引用崩溃

### DIFF
--- a/tm-backend/check_password.py
+++ b/tm-backend/check_password.py
@@ -9,6 +9,9 @@ db = SessionLocal()
 phone = "15812345678"
 password = "zishu"
 user = db.query(Users).filter(Users.phone== phone).first()
+if not user:
+    print("用户不存在")
+    exit(1)
 rst = pwd_context.verify(password, user.password)
 print(user.username)
 print(rst)


### PR DESCRIPTION
check_password.py 在查询用户时未做空值检查，当手机号不存在时 `user` 为 None，后续 `user.password` 会抛出 AttributeError。

修改内容：
- 在 `pwd_context.verify()` 调用前添加 `if not user:` 判断
- 用户不存在时输出提示并退出，避免运行时崩溃