### PR TITLE
清理：移除web_executor.py中未使用的变量has_style

### DIFF
--- a/tm-backend/app/services/web_executor.py
+++ b/tm-backend/app/services/web_executor.py
@@ -214,7 +214,6 @@ class WebExecutor:
         # 检查是否包含 Vue SFC 的特征标签
         has_template = '<template' in code_stripped
         has_script = '<script' in code_stripped
-        has_style = '<style' in code_stripped
         # 如果包含 template 和 script，很可能是 Vue SFC
         # 或者包含 script setup，也是 Vue SFC
         has_script_setup = '<script' in code_stripped and 'setup' in code_stripped


### PR DESCRIPTION
web_executor.py 中 `_detect_vue_sfc` 方法定义了变量 `has_style` 但未在返回值中使用，属于冗余代码。

修改内容：
- 移除未使用的 `has_style` 变量赋值