### PR TITLE
清理：移除statistics.py中未使用的func导入

### DIFF
--- a/tm-backend/app/routers/statistics.py
+++ b/tm-backend/app/routers/statistics.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from sqlalchemy import func, desc
+from sqlalchemy import desc
 from datetime import datetime, timedelta
 from typing import Optional, List
 import os


### PR DESCRIPTION
**修改范围**
`tm-backend/app/routers/statistics.py` 第3行

**问题描述**
`statistics.py` 中导入了 `sqlalchemy.func`，但文件内没有任何地方使用该函数。属于冗余导入。

**修改内容**
将 `from sqlalchemy import func, desc` 改为 `from sqlalchemy import desc`，仅保留实际使用的 `desc`。

**验证**
- `python3 -m py_compile` 语法校验通过
- 全文搜索确认 `func` 在文件中无任何引用