### PR TITLE
清理：移除tutorial.py中未使用的glob导入

### DIFF
--- a/tm-backend/app/routers/tutorial.py
+++ b/tm-backend/app/routers/tutorial.py
@@ -1,5 +1,4 @@
 import os
-import glob
 from datetime import datetime
 from fastapi import APIRouter, HTTPException, Form
 from pydantic import BaseModel


### PR DESCRIPTION
**修改范围**
`tm-backend/app/routers/tutorial.py` 第2行

**问题描述**
`tutorial.py` 中导入了 `glob` 模块，但文件内没有任何地方使用 `glob.glob()` 或其他 glob 功能。教程文件的遍历使用的是 `os.listdir()` 等 os 模块方法。

**修改内容**
移除 `import glob` 行。

**验证**
- `python3 -m py_compile` 语法校验通过
- 全文搜索确认 `glob` 在文件中无任何引用