### PR TITLE
清理：移除config.py中未使用的Any和List导入

### DIFF
--- a/tm-backend/app/routers/config.py
+++ b/tm-backend/app/routers/config.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from typing import Dict, Any, List
+from typing import Dict
 from datetime import datetime
 
 from app.dependencies import check_jwt_token, get_db, require_admin


### PR DESCRIPTION
**修改范围**
`tm-backend/app/routers/config.py` 第3行

**问题描述**
`config.py` 中从 `typing` 导入了 `Any` 和 `List`，但文件内没有任何地方使用这两个类型。仅 `Dict` 被实际使用。

**修改内容**
将 `from typing import Dict, Any, List` 改为 `from typing import Dict`。

**验证**
- `python3 -m py_compile` 语法校验通过
- 全文搜索确认 `Any`、`List` 在文件中无任何引用