### PR TITLE
修复：statistics.py中任务时长统计IndexError异常

### DIFF
--- a/tm-backend/app/routers/statistics.py
+++ b/tm-backend/app/routers/statistics.py
@@ -527,8 +527,8 @@ async def get_user_detail_analysis(
                 other_tasks.append(task)
 
     # 计算平均完成时间
-    planned_hours = sum(len(t) > 4 and t[4] or 0 for t in planned_tasks if isinstance(t[4], (int, float))) / 60
-    actual_hours = sum(len(t) > 7 and t[7] or 0 for t in finished_tasks if isinstance(t[7], (int, float))) / 60
+    planned_hours = sum(t[4] if len(t) > 4 and isinstance(t[4], (int, float)) else 0 for t in planned_tasks) / 60
+    actual_hours = sum(t[7] if len(t) > 7 and isinstance(t[7], (int, float)) else 0 for t in finished_tasks) / 60
 
     return {
         "code": 200,

--- a/tm-backend/app/routers/statistics.py
+++ b/tm-backend/app/routers/statistics.py
@@ -530,8 +530,8 @@ async def get_user_detail_analysis(
                 other_tasks.append(task)
 
     # 计算平均完成时间
-    planned_hours = sum(len(t) > 4 and t[4] or 0 for t in planned_tasks if isinstance(t[4], (int, float))) / 60
-    actual_hours = sum(len(t) > 7 and t[7] or 0 for t in finished_tasks if isinstance(t[7], (int, float))) / 60
+    planned_hours = sum(t[4] if len(t) > 4 and isinstance(t[4], (int, float)) else 0 for t in planned_tasks) / 60
+    actual_hours = sum(t[7] if len(t) > 7 and isinstance(t[7], (int, float)) else 0 for t in finished_tasks) / 60
 
     return {
         "code": 200,


### PR DESCRIPTION
### 问题描述

`get_user_detail_analysis` 接口中，计算计划时长和实际时长的代码使用了生成器表达式的 `if` 过滤条件来检查 `isinstance(t[4], ...)`，但该条件会在检查 `len(t) > 4` 之前访问 `t[4]`，导致当任务数据长度不足时抛出 `IndexError`。

### 复现方式

当用户的任务文件中包含长度小于5的计划任务或长度小于8的已完成任务时，调用 `/personal/detail_analysis` 接口会返回500错误。

### 修复方案

将 `if isinstance(t[N], ...)` 过滤条件改为三元表达式 `t[N] if len(t) > N and isinstance(t[N], ...) else 0`，确保先检查长度再访问索引，避免 IndexError。

### 修改范围

- `tm-backend/app/routers/statistics.py` 第530-531行，仅2行修改

### 验证

- `python3 -m py_compile` 通过
- 本地逻辑验证：短列表不再触发 IndexError，正常数据计算结果不变
