### PR TITLE
完善：统计接口异常捕获补充TypeError防止脏数据500

### DIFF
--- a/tm-backend/app/routers/statistics.py
+++ b/tm-backend/app/routers/statistics.py
@@ -602,7 +602,7 @@ async def get_study_calendar(
                 "value": round(hours, 1),
                 "level": min(4, int(hours / 2))  # 0-4级热力
             })
-        except (ValueError, SyntaxError):
+        except (ValueError, TypeError):
             continue
 
     return {
@@ -714,7 +714,7 @@ async def get_time_analysis(
                     if date_str not in daily_completion:
                         daily_completion[date_str] = 0
                     daily_completion[date_str] += duration / 60
-            except (ValueError, SyntaxError):
+            except (ValueError, TypeError):
                 continue
 
     # 按天统计
@@ -792,7 +792,7 @@ async def get_personal_trend_fixed(
                     if date_str not in daily_data:
                         daily_data[date_str] = 0
                     daily_data[date_str] += duration / 60
-            except (ValueError, SyntaxError):
+            except (ValueError, TypeError):
                 continue
 
     # 生成完整的日期序列

--- a/tm-backend/app/routers/statistics.py
+++ b/tm-backend/app/routers/statistics.py
@@ -605,7 +605,7 @@ async def get_study_calendar(
                 "value": round(hours, 1),
                 "level": min(4, int(hours / 2))  # 0-4级热力
             })
-        except (ValueError, SyntaxError):
+        except (ValueError, TypeError):
             continue
 
     return {
@@ -717,7 +717,7 @@ async def get_time_analysis(
                     if date_str not in daily_completion:
                         daily_completion[date_str] = 0
                     daily_completion[date_str] += duration / 60
-            except (ValueError, SyntaxError):
+            except (ValueError, TypeError):
                 continue
 
     # 按天统计
@@ -795,7 +795,7 @@ async def get_personal_trend_fixed(
                     if date_str not in daily_data:
                         daily_data[date_str] = 0
                     daily_data[date_str] += duration / 60
-            except (ValueError, SyntaxError):
+            except (ValueError, TypeError):
                 continue
 
     # 生成完整的日期序列


### PR DESCRIPTION
### 背景

PR #56 因与已合并的 PR #53 产生合并冲突无法自动合并。本 PR 基于 main 最新代码重新实现了 TypeError 补充修复。

### 问题描述

统计接口中，`datetime.strptime` 可能抛出 `ValueError`，而 `duration / 60` 在 duration 非数值时会抛出 `TypeError`。当前的 `except (ValueError, SyntaxError)` 没有覆盖 TypeError，脏数据会导致接口返回 500 错误。

### 修复方案

将统计逻辑中的异常捕获从 `except (ValueError, SyntaxError)` 改为 `except (ValueError, TypeError)`。

注意：`read_user_file` 函数中的 `ast.literal_eval` 异常捕获保持 `except (ValueError, SyntaxError)` 不变，因为该场景下 SyntaxError 是合理的异常类型。

### 修改范围

- `tm-backend/app/routers/statistics.py` 第 605、717、795 行，共 3 行修改

### 验证

- `python3 -m py_compile` 通过
- 异常类型选择与各调用点实际可能抛出的异常一致
