### PR TITLE
修复：/add_shuzhi接口添加JWT身份验证

### DIFF
--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -829,7 +829,7 @@ async def fetch_shuzhi(userid: int):
 
 
 @router.post("/add_shuzhi")
-async def add_shuzhi(request: Request, db: Session = Depends(get_db)):
+async def add_shuzhi(request: Request, user: TokenModel = Depends(check_jwt_token), db: Session = Depends(get_db)):
     """添加塾值记录"""
     try:
         data = await request.json()


### PR DESCRIPTION
## 修改说明

`/api/users/add_shuzhi` 接口原实现中缺少JWT身份验证，当前端请求时无需携带有效Token即可调用，存在安全隐患。

## 修复内容

为 `add_shuzhi` 接口添加 `check_jwt_token` 依赖注入，与同文件其他接口（如 `save_profile`、`get_profile`）保持一致。

## 验证

- Python语法校验通过
- 未影响其他接口逻辑
