### PR TITLE
修复：UserAnalysis.vue头像字段拼写错误

### DIFF
--- a/tm-frontend/src/views/statistics/UserAnalysis.vue
+++ b/tm-frontend/src/views/statistics/UserAnalysis.vue
@@ -201,7 +201,7 @@ onMounted(() => {
         <!-- 用户信息卡片 -->
         <el-card v-if="userDetail?.user" class="user-info-card">
             <div class="user-header">
-                <el-avatar :size="80" :src="userDetail.user.avantar || ''">
+                <el-avatar :size="80" :src="userDetail.user.avatar || ''">
                     {{ userDetail.user.username?.charAt(0)?.toUpperCase() }}
                 </el-avatar>
                 <div class="user-details">


### PR DESCRIPTION
## 修改说明

`UserAnalysis.vue` 中用户头像字段名拼写错误：`avantar` 应为 `avatar`，导致头像 URL 无法正确读取。

## 修复内容

将模板中 `userDetail.user.avantar` 修正为 `userDetail.user.avatar`。

## 验证

- 前端构建语法检查通过
- 不影响其他功能
