### PR TITLE
修复：替换已弃用的asyncio.get_event_loop()为get_running_loop()

### DIFF
--- a/tm-backend/app/services/python_executor.py
+++ b/tm-backend/app/services/python_executor.py
@@ -253,7 +253,7 @@ e = math.e
             }
 
         # 在线程池中执行（避免阻塞）
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(
             None,
             lambda: self._execute_with_docker(code, timeout)


### PR DESCRIPTION
## 修改内容

替换 `python_executor.py` 中已弃用的 `asyncio.get_event_loop()` 调用为 `asyncio.get_running_loop()`。

## 背景

`asyncio.get_event_loop()` 自 Python 3.10 起已标记为弃用，在 Python 3.12+ 中行为发生了变化。由于该函数已经在 async 上下文中调用（`async def` 方法内部），使用 `asyncio.get_running_loop()` 是正确的替代方案，语义也更明确。

## 修改范围

- `tm-backend/app/services/python_executor.py`：第 256 行，1 行修改

## 验证

- `python3 -m py_compile` 通过
- `ruff check` 无新增告警
- 功能行为不变，仅消除弃用警告
