### PR TITLE
清理：移除sql_executor.py中未使用的re导入

### DIFF
--- a/tm-backend/app/services/sql_executor.py
+++ b/tm-backend/app/services/sql_executor.py
@@ -3,7 +3,6 @@ SQL 代码执行器
 使用 SQLite 内存数据库执行 SQL 查询
 """
 import sqlite3
-import re
 from typing import Dict, Any, List, Tuple
 
 


### PR DESCRIPTION
## 修改内容

移除 `sql_executor.py` 中未使用的 `import re`。

## 背景

`re` 模块在 `sql_executor.py` 中被导入但从未被引用。ruff 检查报告 F401 错误。

## 修改范围

- `tm-backend/app/services/sql_executor.py`：移除第 6 行 `import re`

## 验证

- `python3 -m py_compile` 通过
- `ruff check` 全部通过
