### PR TITLE
修复：用户页面缺失导入问题

### DIFF
--- a/tm-frontend/src/views/user/All.vue
+++ b/tm-frontend/src/views/user/All.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { fetchAllUsersAPI } from '../../request/user/api'
-import { onMounted, reactive, ref } from 'vue'
+import { onMounted, reactive, ref, computed } from 'vue'
 import { useLoginStore } from '../../store'
 import { ElTable, ElMessage } from 'element-plus'
 
@@ -83,10 +83,6 @@ const maskPhone = (phone: string) => {
     </el-card>
   </div>
 </template>
-
-<script lang="ts">
-import { computed } from 'vue'
-</script>
 
 <style scoped>
 .all-container {

--- a/tm-frontend/src/views/user/Registers.vue
+++ b/tm-frontend/src/views/user/Registers.vue
@@ -2,7 +2,7 @@
 import { fetchRigiAPI, handleRigiAPI } from '../../request/user/api'
 import { onMounted, ref, reactive } from 'vue'
 import { ElTable, ElMessage } from 'element-plus'
-import { Check, Delete } from '@element-plus/icons-vue'
+import { Check, Delete, Refresh } from '@element-plus/icons-vue'
 
 document.title = '注册审核'
 


### PR DESCRIPTION
## 修改说明

修复前端用户管理页面的导入缺失问题，共涉及两个文件：

### 1. `tm-frontend/src/views/user/All.vue`
- **问题**：`computed` 在 `<script setup>` 中使用但未从 `vue` 导入，导致页面运行时崩溃
- **修复**：将 `computed` 添加到 `<script setup>` 的 `vue` 导入语句中，同时移除底部冗余的 `<script lang="ts">` 块

### 2. `tm-frontend/src/views/user/Registers.vue`
- **问题**：模板中使用 `<Refresh />` 图标组件但未导入 `Refresh` 图标，导致页面渲染异常
- **修复**：将 `Refresh` 添加到 `@element-plus/icons-vue` 的导入列表中

### 验证
- 修改范围：仅涉及导入语句，逻辑零改动
- 无新增依赖
- 不影响其他页面功能
