### PR TITLE
清理冗余导入和注释代码

### DIFF
--- a/tm-backend/app/dependencies.py
+++ b/tm-backend/app/dependencies.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-from . import config
 from .database import SessionLocal
 from typing import Optional
 from fastapi import Header, HTTPException, status, Depends
@@ -49,11 +47,6 @@ def check_jwt_token(token: Optional[str] = Header(""), db: Session = Depends(get
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=settings.ALGORITHM)
         id: str = payload.get("sub")
-        # 得到令牌过期时间
-        expiration_timestamp = payload.get("exp")
-        # 把令牌过期时间转化为人类可读时间信息
-        # expiration_time = datetime.fromtimestamp(expiration_timestamp)
-        # print(expiration_time)
         # 通过解析得到的username,获取用户信息,并返回
         # return users_db.get(username)
         return db.query(users.Users).filter(users.Users.id== int(id)).first()

--- a/tm-backend/app/routers/inno.py
+++ b/tm-backend/app/routers/inno.py
@@ -1,11 +1,9 @@
-from fastapi import APIRouter, Form, Depends, HTTPException, status, Request
-from datetime import datetime, timedelta
-from app.dependencies import check_jwt_token, get_db
-from sqlalchemy.orm import Session
-from app.core.schemas.users import UserBase
-from app.core.models.users import Users, Base
+from fastapi import APIRouter, Request
+from app.core.models.users import Base
 from app.database import engine
-import json, os, ast
+import json
+import os
+import ast
 
 
 Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
## 修改内容

清理 `app/routers/inno.py` 和 `app/dependencies.py` 中的冗余导入和注释代码：

### app/routers/inno.py
- 移除未使用的导入：`Form`, `Depends`, `HTTPException`, `status`（来自 fastapi）
- 移除未使用的导入：`datetime`, `timedelta`（来自 datetime）
- 移除未使用的导入：`check_jwt_token`, `get_db`（来自 app.dependencies）
- 移除未使用的导入：`Session`（来自 sqlalchemy.orm）
- 移除未使用的导入：`UserBase`（来自 app.core.schemas.users）
- 移除未使用的导入：`Users`（来自 app.core.models.users）
- 修正多行导入格式（`import json, os, ast` → 分行导入）

### app/dependencies.py
- 移除未使用的导入：`datetime`（来自 datetime）
- 移除未使用的导入：`config`（来自 .）
- 移除注释掉的过期代码和未使用变量 `expiration_timestamp`

## 验证

- ✅ `python3 -m py_compile` 语法检查通过
- ✅ `ruff check` lint 检查通过
- ✅ 无功能逻辑变更，仅清理无用代码
