### PR TITLE
修复：token判空使用严格等于运算符

### DIFF
--- a/tm-frontend/src/request/base.ts
+++ b/tm-frontend/src/request/base.ts
@@ -28,7 +28,7 @@ async function refreshToken() {
 // request拦截器
 instance.interceptors.request.use(
     config => {
-        if (loginstate.atoken == '') {
+        if (loginstate.atoken === '') {
             //添加请求头
             config.headers["token"] = loginstate.rtoken
         } else {


### PR DESCRIPTION
将 `base.ts` 中请求拦截器的 token 判空从 `==` 改为严格等于 `===`，符合 TypeScript 最佳实践。

修改范围：`tm-frontend/src/request/base.ts` 第31行

影响：仅改变比较运算符，不影响逻辑判断结果