### PR TITLE
清理：移除users.py中未使用的requests、UploadFile、File导入

### DIFF
--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Form, Depends, HTTPException, status, Request, UploadFile, File
+from fastapi import APIRouter, Form, Depends, HTTPException, status, Request
 from datetime import datetime, timedelta
 import logging
 
@@ -6,7 +6,6 @@ logger = logging.getLogger(__name__)
 from app.dependencies import check_jwt_token, get_db, verify_password, get_password_hash, require_admin
 from app.config import settings
 from jose import jwt
-import requests
 import os
 import json
 import glob


### PR DESCRIPTION
移除 `users.py` 中未使用的三个导入：

- `requests`（未在文件中引用）
- `UploadFile`（未在文件中引用）
- `File`（未在文件中引用）

修改范围：`tm-backend/app/routers/users.py` 导入部分

验证：`py_compile` 语法检查通过