### PR TITLE
清理：移除statistics.py中未使用的or_导入

### DIFF
--- a/tm-backend/app/routers/statistics.py
+++ b/tm-backend/app/routers/statistics.py
@@ -319,7 +319,6 @@ async def get_users_learning_list(
     """获取所有用户学习情况列表（所有认证用户可见）"""
     from app.core.models.users import Users
     from app.core.models.config import SystemConfig
-    from sqlalchemy import or_
 
     # 获取不活跃阈值配置
     config = db.query(SystemConfig).filter(SystemConfig.key == "inactive_days_threshold").first()


### PR DESCRIPTION
移除 `statistics.py` 的 `get_users_learning_list` 函数中未使用的 `or_` 导入。

该函数导入了 `from sqlalchemy import or_`，但函数内部并未使用 `or_` 进行查询过滤。

修改范围：`tm-backend/app/routers/statistics.py` 第319行

验证：`py_compile` 语法检查通过