### PR TITLE
修复：错误响应不再暴露内部异常详情

### DIFF
--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -867,8 +867,8 @@ async def add_shuzhi(request: Request, db: Session = Depends(get_db)):
             db.commit()
 
         return {"code": 200, "message": "添加成功"}
-    except Exception as e:
-        return {"code": 500, "message": str(e)}
+    except Exception:
+        return {"code": 500, "message": "操作失败，请稍后重试"}
 
 
 @router.post("/update_user_role")
@@ -890,9 +890,9 @@ async def update_user_role(request: Request, user: TokenModel = Depends(require_
         db.commit()
 
         return {"code": 200, "message": "角色更新成功"}
-    except Exception as e:
+    except Exception:
         db.rollback()
-        return {"code": 500, "message": str(e)}
+        return {"code": 500, "message": "操作失败，请稍后重试"}
 
 
 @router.get("/fetch_permissions")
@@ -946,5 +946,5 @@ async def save_permissions(request: Request, user: TokenModel = Depends(require_
                 f.write(str(perm) + "\n")
 
         return {"code": 200, "message": "权限配置已保存"}
-    except Exception as e:
-        return {"code": 500, "message": str(e)}
+    except Exception:
+        return {"code": 500, "message": "操作失败，请稍后重试"}


### PR DESCRIPTION
将 `users.py` 中三处异常处理返回的 `str(e)` 替换为通用错误提示，避免将内部异常详情暴露给客户端。

涉及接口：
- `/add_shuzhi` — 塾值添加异常
- `/update_user_role` — 角色更新异常
- `/save_permissions` — 权限保存异常

修改范围：`tm-backend/app/routers/users.py` 第868、892、947行

验证：`py_compile` 语法检查通过