### PR TITLE
修复：移除get_profile中不必要的目录创建操作

### DIFF
--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -667,8 +667,6 @@ async def get_profile(*, user_id: int, user: TokenModel = Depends(check_jwt_toke
     rtn['location']=useritem.location or ''
     rtn['desc']=useritem.desc or ''
     save_base_dir = "static/uploads/profiles/"
-    if not os.path.exists(save_base_dir):
-        os.makedirs(save_base_dir)
     tmplist = []
     for i in range(0,5):
         pattern = str(user_id)+"_"+str(i)+"*.jpg"


### PR DESCRIPTION
移除 `get_profile` 接口中不必要的 `os.makedirs` 调用。

GET 请求中创建目录不符合职责分离原则，目录创建应仅在写入操作（如 `save_profile`）中执行。
移除后不影响功能，因为：
1. `glob.glob` 对不存在的目录返回空列表，不会报错
2. 目录创建已在上传接口中处理