### PR TITLE
修复：管理员判断移除硬编码的用户ID检查

### DIFF
--- a/tm-frontend/src/router/index.ts
+++ b/tm-frontend/src/router/index.ts
@@ -182,7 +182,7 @@ router.beforeEach(async (to, from, next) => {
 
   const isAuthenticated = userStore.logined && !!userStore.atoken
   const userRole = userStore.role || 'user'
-  const isAdmin = userStore.id === 1 || userRole === 'admin'
+  const isAdmin = userRole === 'admin'
 
   // 需要认证的路由
   if (to.meta.requiresAuth) {


### PR DESCRIPTION
移除路由守卫中管理员判断的硬编码 `userStore.id === 1` 条件。

管理员权限应统一通过 `userRole === 'admin'` 判断，而非依赖特定的用户 ID。
硬编码 ID 在管理员变更时会失效，且与后端角色体系不一致。