### PR TITLE
清理：移除前端调试用console.log语句

### DIFF
--- a/tm-frontend/src/request/base.ts
+++ b/tm-frontend/src/request/base.ts
@@ -62,10 +62,8 @@ instance.interceptors.response.use(
         // 处理401错误 - token过期
         if (data?.detail?.code === 5000 && config && !config.url?.includes('/refresh')) {
             loginstate.atoken = ''
-            console.log("准备刷新token");
             try {
                 const res = await refreshToken();
-                console.log(res);
                 if (res && res.id > 0) {
                     return instance(config);
                 } else {

--- a/tm-frontend/src/views/Study.vue
+++ b/tm-frontend/src/views/Study.vue
@@ -290,7 +290,6 @@ const submitReport = async () => {
 const beforeUnload = () => {
   if (studyTimer.value > 60) {
     // 实际项目中这里可以发送请求
-    console.log('学习时长:', studyTimer.value)
   }
 }
 


### PR DESCRIPTION
移除前端代码中的调试用 `console.log` 语句：

- `tm-frontend/src/request/base.ts`：移除 token 刷新流程中的 2 处 console.log
- `tm-frontend/src/views/Study.vue`：移除页面离开时的学习时长日志输出

`console.error` 用于错误处理的保留不变。