### PR TITLE
优化：将数据库表初始化从路由模块移至应用启动入口

### DIFF
--- a/tm-backend/app/routers/inno.py
+++ b/tm-backend/app/routers/inno.py
@@ -11,8 +11,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-Base.metadata.create_all(bind=engine)
-
 inno = APIRouter(
     prefix="/api/inno",
     tags=["inno"],

--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -22,7 +22,6 @@ from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 import smtplib
 # from app.core.config import settings
-Base.metadata.create_all(bind=engine)
 
 router = APIRouter(
     prefix="/api/users",

--- a/tm-backend/main.py
+++ b/tm-backend/main.py
@@ -13,6 +13,11 @@ from app.routers import code_execution
 from app.routers import config
 
 from app.config import settings
+from app.core.models.users import Base
+from app.database import engine
+
+# 初始化数据库表结构
+Base.metadata.create_all(bind=engine)
 
 # 配置日志格式
 logging.basicConfig(


### PR DESCRIPTION
将 `Base.metadata.create_all(bind=engine)` 从路由模块（`users.py`、`inno.py`）移至应用启动入口 `main.py`。

路由模块在每次被导入时都会执行模块级代码，将数据库表初始化放在这里存在以下问题：
- 多次导入时重复执行不必要的 DDL 操作
- 路由模块职责不清晰
- 与 Alembic 迁移管理冲突

移至 `main.py` 应用启动时统一初始化，更符合 FastAPI 最佳实践。