### PR TITLE
修复：移除sys模块的安全限制，与预导入保持一致

### DIFF
--- a/tm-backend/app/services/python_executor.py
+++ b/tm-backend/app/services/python_executor.py
@@ -57,8 +57,6 @@ e = math.e
         r'\bfrom\s+os\s+import',       # from os import
         r'\bimport\s+subprocess\b',    # import subprocess
         r'\bfrom\s+subprocess\s+import',  # from subprocess import
-        r'\bimport\s+sys\b',           # import sys
-        r'\bfrom\s+sys\s+import',      # from sys import
         r'\b__import__\s*\(',          # __import__()
         r'\beval\s*\(',                # eval()
         r'\bexec\s*\(',                # exec()


### PR DESCRIPTION
移除 `python_executor.py` 中对 `sys` 模块的导入限制。

`sys` 已在 `PREIMPORTED_MODULES` 中预导入供教程代码使用，但同时又被列入 `FORBIDDEN_PATTERNS`，导致用户无法在代码中使用 `sys`。

移除限制后用户可以直接使用预导入的 `sys` 模块（如 `sys.path`、`sys.argv`），与预导入策略保持一致。