### PR TITLE
修复：移除用户注册接口中调试用的print语句

### DIFF
--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -250,9 +250,7 @@ async def register(request: Request, name: str = Form(...), password: str = Form
             detail=error_msg
         )
     
-    print(name, email)
     form_data = await request.form()
-    print(form_data.get("phone"))
     # 检查手机号是否已注册
     existing_user = db.query(Users).filter(Users.phone == phone).first()
     existing_register = db.query(Register).filter(Register.phone == phone).first()


### PR DESCRIPTION
## 修改说明

移除用户注册接口（`/register`）中调试用的 `print` 语句，避免生产环境日志泄露用户敏感信息。

## 修改内容

- 删除 `users.py` 中的 `print(name, email)` 和 `print(form_data.get("phone"))` 调试语句

## 验证结果

- [x] Python 语法检查通过
- [x] ruff lint 检查通过
- [x] 仅删除调试语句，未改动业务逻辑

## 影响范围

仅影响用户注册接口的日志输出，不影响注册功能本身。