### PR TITLE
清理：移除前端调试用console.log语句

### DIFF
--- a/tm-frontend/src/request/base.ts
+++ b/tm-frontend/src/request/base.ts
@@ -62,10 +62,8 @@ instance.interceptors.response.use(
         // 处理401错误 - token过期
         if (data?.detail?.code === 5000 && config && !config.url?.includes('/refresh')) {
             loginstate.atoken = ''
-            console.log("准备刷新token");
             try {
                 const res = await refreshToken();
-                console.log(res);
                 if (res && res.id > 0) {
                     return instance(config);
                 } else {

--- a/tm-frontend/src/views/Study.vue
+++ b/tm-frontend/src/views/Study.vue
@@ -290,7 +290,6 @@ const submitReport = async () => {
 const beforeUnload = () => {
   if (studyTimer.value > 60) {
     // 实际项目中这里可以发送请求
-    console.log('学习时长:', studyTimer.value)
   }
 }
 


### PR DESCRIPTION
## 修改说明

移除前端代码中调试用的 `console.log` 语句，避免生产环境浏览器控制台输出敏感信息。

## 修改内容

1. **Study.vue**: 删除 `beforeUnload` 函数中的 `console.log('学习时长:', studyTimer.value)` 调试语句
2. **base.ts**: 删除 token 刷新逻辑中的两处 `console.log` 调试语句

## 验证结果

- [x] TypeScript 语法检查通过
- [x] 仅删除调试语句，未改动业务逻辑
- [x] 不影响 token 刷新和错误处理功能

## 影响范围

- 仅影响开发时浏览器控制台输出，不影响任何功能逻辑