### PR TITLE
清理：移除执行器中未使用的导入和变量

### DIFF
--- a/tm-backend/app/services/sql_executor.py
+++ b/tm-backend/app/services/sql_executor.py
@@ -3,7 +3,6 @@ SQL 代码执行器
 使用 SQLite 内存数据库执行 SQL 查询
 """
 import sqlite3
-import re
 from typing import Dict, Any, List, Tuple
 
 

--- a/tm-backend/app/services/web_executor.py
+++ b/tm-backend/app/services/web_executor.py
@@ -214,7 +214,6 @@ class WebExecutor:
         # 检查是否包含 Vue SFC 的特征标签
         has_template = '<template' in code_stripped
         has_script = '<script' in code_stripped
-        has_style = '<style' in code_stripped
         # 如果包含 template 和 script，很可能是 Vue SFC
         # 或者包含 script setup，也是 Vue SFC
         has_script_setup = '<script' in code_stripped and 'setup' in code_stripped
@@ -332,7 +331,6 @@ class WebExecutor:
 
     def _process_setup_script(self, script_code: str, template: str) -> str:
         """处理 <script setup> 格式的代码"""
-        import re
 
         # 1. 移除 ES6 imports
         script_code = self._clean_imports(script_code)


### PR DESCRIPTION
## 修改内容

清理执行器模块中的冗余代码：

### app/services/sql_executor.py
- 移除未使用的 `re` 导入

### app/services/web_executor.py
- 移除未使用的局部变量 `has_style`
- 移除 `_process_setup_script` 方法中未使用的 `import re`

## 验证

- `python3 -m py_compile` 语法检查通过
- `ruff check` lint 检查通过
- 无功能逻辑变更，仅清理无用代码
