### PR TITLE
清理：移除python_executor.py中未使用的异常捕获变量e

### DIFF
--- a/tm-backend/app/services/python_executor.py
+++ b/tm-backend/app/services/python_executor.py
@@ -173,7 +173,7 @@ e = math.e
                 'stderr': f'执行超时（{timeout}秒）',
                 'exitCode': -1
             }
-        except Exception as e:
+        except Exception:
             # Docker 不可用，回退到 subprocess 方式（注意：full_code 已在上面构造）
             return self._execute_with_subprocess(code, timeout)
 


### PR DESCRIPTION
## 修改内容

移除 `tm-backend/app/services/python_executor.py` 中 Docker 异常捕获时未使用的变量 `e`。

## 问题说明

`execute()` 方法的 Docker 异常捕获 `except Exception as e` 中，变量 `e` 从未被使用（仅回退到 subprocess 方式），属于冗余赋值。

## 修改范围

- `tm-backend/app/services/python_executor.py`：`except Exception as e` → `except Exception`

## 验证

- 语法校验通过（py_compile）
- ruff check 确认修改正确
- 仅改动 1 行，不影响任何业务逻辑