### PR TITLE
新增：学习计时器在浏览器标签页实时显示学习时长

### DIFF
--- a/tm-frontend/src/views/Study.vue
+++ b/tm-frontend/src/views/Study.vue
@@ -135,12 +135,18 @@ const loadLesson = async (path: string, title: string, chapter: string) => {
   }
 }
 
+// 页面原始标题，用于离开时恢复
+const originalTitle = '学习'
+
 // 开始学习计时
 const startTimer = () => {
   stopTimer()
   studyTimer.value = 0
   timerInterval.value = window.setInterval(() => {
     studyTimer.value++
+    // 在浏览器标签页实时显示学习时长
+    const title = currentTitle.value || '学习'
+    document.title = `${formatTime(studyTimer.value)} - ${title}`
   }, 1000)
 }
 
@@ -149,6 +155,8 @@ const stopTimer = () => {
   if (timerInterval.value) {
     clearInterval(timerInterval.value)
     timerInterval.value = null
+    // 恢复原始标题
+    document.title = currentTitle.value || originalTitle
   }
 }
 


### PR DESCRIPTION
## 新增功能

学习页面计时器运行时，在浏览器标签页标题实时显示学习时长（如 `03:25 - Vue3入门`），方便用户切换到其他标签页时仍能随时掌握学习时间。

## 实现方案

- 修改 `Study.vue` 中 `startTimer()` 的 `setInterval` 回调，每秒同步更新 `document.title`
- 格式为 `MM:SS - 课时标题`，与页面内的计时显示格式一致
- 停止计时（`stopTimer()`）时恢复为课时标题
- 页面离开（`onUnmounted`）时通过已有的 `stopTimer()` 调用自动恢复

## 修改范围

- `tm-frontend/src/views/Study.vue`：8行新增，无删除

## 验证

- 逻辑正确：计时器启动→标签页实时更新，计时器停止→恢复原标题
- 不影响原有功能：`loadLesson` 和 `onUnmounted` 的标题设置逻辑不变
- 改动极小（8行），纯显示层增强