### PR TITLE
清理：移除调试代码遗留的print语句和未使用变量

### DIFF
--- a/tm-backend/app/dependencies.py
+++ b/tm-backend/app/dependencies.py
@@ -49,10 +49,7 @@ def check_jwt_token(token: Optional[str] = Header(""), db: Session = Depends(get
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=settings.ALGORITHM)
         id: str = payload.get("sub")
-        # 得到令牌过期时间
-        expiration_timestamp = payload.get("exp")
-        # 把令牌过期时间转化为人类可读时间信息
-        # expiration_time = datetime.fromtimestamp(expiration_timestamp)
+        # 令牌过期时间通过 JWT 库自动校验
         # print(expiration_time)
         # 通过解析得到的username,获取用户信息,并返回
         # return users_db.get(username)

--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -250,9 +250,6 @@ async def register(request: Request, name: str = Form(...), password: str = Form
             detail=error_msg
         )
     
-    print(name, email)
-    form_data = await request.form()
-    print(form_data.get("phone"))
     # 检查手机号是否已注册
     existing_user = db.query(Users).filter(Users.phone == phone).first()
     existing_register = db.query(Register).filter(Register.phone == phone).first()


### PR DESCRIPTION
## 修改说明

移除代码中遗留的调试代码：

1. **dependencies.py**：移除 `check_jwt_token` 函数中获取后未使用的 `expiration_timestamp` 变量及相关注释代码

2. **users.py**：移除用户注册接口中调试用的 `print(name, email)` 和 `print(form_data.get("phone"))` 语句，以及获取后未使用的 `form_data` 变量

## 验证

- Python 语法检查通过
- 仅涉及注释和无用代码移除，不影响业务逻辑
