### PR TITLE
新增：添加健康检查接口/api/health

### DIFF
--- a/tm-backend/app/routers/health.py
+++ b/tm-backend/app/routers/health.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter
+from sqlalchemy import text
+from datetime import datetime
+
+from app.database import SessionLocal
+
+router = APIRouter(prefix="/api", tags=["健康检查"])
+
+
+@router.get("/health")
+async def health_check():
+    """健康检查接口，返回服务状态和数据库连接状态"""
+    status = "healthy"
+    db_status = "connected"
+
+    try:
+        db = SessionLocal()
+        db.execute(text("SELECT 1"))
+        db.close()
+    except Exception:
+        db_status = "disconnected"
+        status = "unhealthy"
+
+    return {
+        "status": status,
+        "timestamp": datetime.now().isoformat(),
+        "database": db_status
+    }

--- a/tm-backend/main.py
+++ b/tm-backend/main.py
@@ -11,6 +11,7 @@ from app.routers import tutorial
 from app.routers import statistics
 from app.routers import code_execution
 from app.routers import config
+from app.routers import health
 
 from app.config import settings
 
@@ -45,6 +46,7 @@ app.include_router(tutorial.router, prefix="/api/tutorial")
 app.include_router(statistics.router)
 app.include_router(code_execution.router, prefix="/api/code")
 app.include_router(config.router)
+app.include_router(health.router)
 
 @app.get("/")
 def read_root():


### PR DESCRIPTION
添加 `/api/health` 健康检查接口，用于监控服务状态和数据库连接状态。

**修改内容：**
- 新增 `tm-backend/app/routers/health.py` 健康检查路由
- 在 `main.py` 中注册健康检查路由

**接口说明：**
- `GET /api/health` — 返回服务运行状态、当前时间戳、数据库连接状态

**验证：**
- 语法校验通过（py_compile）
- 模块导入测试通过，路由正确注册到 `/api/health`
- 代码风格与项目现有路由模块保持一致