### PR TITLE
新增：添加日志模块，替换调试用print语句

### DIFF
--- a/tm-backend/app/routers/inno.py
+++ b/tm-backend/app/routers/inno.py
@@ -6,6 +6,9 @@ from app.core.schemas.users import UserBase
 from app.core.models.users import Users, Base
 from app.database import engine
 import json, os, ast
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 Base.metadata.create_all(bind=engine)
@@ -101,7 +104,7 @@ async def add_study_time(request: Request, user_id:int):
                         tasklist_str = parsed['taskinfo'][0]
                         tasklist = json.loads(tasklist_str)
                 except Exception as parse_err:
-                    print(f"URL解析错误: {parse_err}")
+                    logger.warning("URL解析错误: %s", parse_err)
 
         # 读取现有数据
         existing_pr = []

--- a/tm-backend/app/routers/statistics.py
+++ b/tm-backend/app/routers/statistics.py
@@ -5,6 +5,9 @@ from datetime import datetime, timedelta
 from typing import Optional, List
 import os
 import ast
+import logging
+
+logger = logging.getLogger(__name__)
 
 from app.dependencies import check_jwt_token, get_db, require_admin
 from app.core.schemas.users import TokenModel
@@ -26,7 +29,7 @@ def read_user_file(filepath: str) -> List:
                         except (ValueError, SyntaxError):
                             continue
         except Exception as e:
-            print(f"读取文件失败 {filepath}: {e}")
+            logger.warning("读取文件失败 %s: %s", filepath, e)
     return data
 
 

--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -1,5 +1,8 @@
 from fastapi import APIRouter, Form, Depends, HTTPException, status, Request, UploadFile, File
 from datetime import datetime, timedelta
+import logging
+
+logger = logging.getLogger(__name__)
 from app.dependencies import check_jwt_token, get_db, verify_password, get_password_hash, require_admin
 from app.config import settings
 from jose import jwt
@@ -250,9 +253,9 @@ async def register(request: Request, name: str = Form(...), password: str = Form
             detail=error_msg
         )
     
-    print(name, email)
+    logger.debug("用户注册: name=%s, email=%s", name, email)
     form_data = await request.form()
-    print(form_data.get("phone"))
+    logger.debug("注册手机号: %s", form_data.get("phone"))
     # 检查手机号是否已注册
     existing_user = db.query(Users).filter(Users.phone == phone).first()
     existing_register = db.query(Register).filter(Register.phone == phone).first()

--- a/tm-backend/main.py
+++ b/tm-backend/main.py
@@ -1,4 +1,5 @@
 import uvicorn
+import logging
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
@@ -12,6 +13,12 @@ from app.routers import code_execution
 from app.routers import config
 
 from app.config import settings
+
+# 配置日志格式
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 
 app = FastAPI()
 app.mount("/api/static", StaticFiles(directory="static"), name="static")


### PR DESCRIPTION
添加 Python logging 模块，替换后端代码中的 print 调试语句为标准日志输出。

**修改内容：**
- `main.py` — 添加 logging.basicConfig 配置，设置统一日志格式
- `users.py` — 添加 logger，替换注册接口中的 print 语句为 logger.debug
- `statistics.py` — 添加 logger，替换文件读取异常中的 print 为 logger.warning
- `inno.py` — 添加 logger，替换 URL 解析错误中的 print 为 logger.warning

**验证：**
- 所有修改文件通过 py_compile 语法校验
- logging 模块导入和输出格式验证通过
- 代码风格与项目现有代码保持一致