### PR TITLE
优化：教程目录结构解析添加5分钟缓存

### DIFF
--- a/tm-backend/app/routers/tutorial.py
+++ b/tm-backend/app/routers/tutorial.py
@@ -1,6 +1,8 @@
 import os
+import time
 import glob
 from datetime import datetime
+from functools import lru_cache
 from fastapi import APIRouter, HTTPException, Form
 from pydantic import BaseModel
 from typing import List, Optional
@@ -14,6 +16,11 @@ current_dir = os.path.dirname(os.path.abspath(__file__))  # .../tm-backend/app/r
 for _ in range(3):
     current_dir = os.path.dirname(current_dir)
 TUTORIAL_BASE_DIR = os.path.join(current_dir, "tutorial")
+
+# 教程结构缓存（5分钟有效期）
+_cached_courses = None
+_cache_timestamp = 0.0
+_CACHE_TTL = 300  # 缓存有效期：5分钟
 
 
 class TutorialFile(BaseModel):
@@ -33,7 +40,13 @@ class CourseInfo(BaseModel):
 
 
 def parse_tutorial_structure():
-    """解析教程目录结构"""
+    """解析教程目录结构（带5分钟缓存）"""
+    global _cached_courses, _cache_timestamp
+
+    now = time.time()
+    if _cached_courses is not None and (now - _cache_timestamp) < _CACHE_TTL:
+        return _cached_courses
+
     courses = []
 
     if not os.path.exists(TUTORIAL_BASE_DIR):
@@ -100,6 +113,8 @@ def parse_tutorial_structure():
                 'chapters': list(chapters.values())
             })
 
+    _cached_courses = courses
+    _cache_timestamp = time.time()
     return courses
 
 


### PR DESCRIPTION
教程目录结构解析 `parse_tutorial_structure()` 每次请求都会遍历整个 tutorial 文件系统（os.walk），对于包含 13+ 课程的目录结构来说 I/O 开销较大。由于教程文件变更频率很低，添加 5 分钟 TTL 缓存避免重复解析。

**修改内容：**
- 添加模块级缓存变量 `_cached_courses` 和 `_cache_timestamp`
- 在 `parse_tutorial_structure()` 中添加缓存命中判断：缓存有效期内直接返回缓存结果
- 缓存过期后重新解析目录并更新缓存

**性能影响：**
- 缓存命中时避免 os.walk 遍历，响应时间从毫秒级降至微秒级
- 5 分钟 TTL 保证教程内容更新后最长 5 分钟内可见

**验证：**
- 语法校验通过（py_compile）
- 缓存命中/未命中逻辑单元验证通过