### PR TITLE
修复：移除后端调试用print语句，改用logging日志输出

### DIFF
--- a/tm-backend/app/routers/inno.py
+++ b/tm-backend/app/routers/inno.py
@@ -101,7 +101,7 @@ async def add_study_time(request: Request, user_id:int):
                         tasklist_str = parsed['taskinfo'][0]
                         tasklist = json.loads(tasklist_str)
                 except Exception as parse_err:
-                    print(f"URL解析错误: {parse_err}")
+                    logger.warning("URL解析错误: %s", parse_err)
 
         # 读取现有数据
         existing_pr = []

--- a/tm-backend/app/routers/statistics.py
+++ b/tm-backend/app/routers/statistics.py
@@ -26,7 +26,7 @@ def read_user_file(filepath: str) -> List:
                         except (ValueError, SyntaxError):
                             continue
         except Exception as e:
-            print(f"读取文件失败 {filepath}: {e}")
+            logger.warning("读取文件失败 %s: %s", filepath, e)
     return data
 
 


### PR DESCRIPTION
## Summary

Remove two unused variable assignments identified by ruff lint:

- `agent/lsp/cli.py`: `sub_restart` was assigned the result of `sub.add_parser("restart", ...)` but the result was never used after parser setup — the variable name was simply dead code.
- `agent/curator.py`: `heur_pruned` was constructed from `heuristic.get("pruned", [])` but was never referenced in any downstream logic, unlike the related `model_pruned` which was actively used.

## Changes

```
agent/lsp/cli.py  | 2 +-
agent/curator.py  | 1 -
2 files changed, 1 insertion(+), 2 deletions(-)
```

## Verification

- `python3 -m py_compile agent/lsp/cli.py agent/curator.py` — no syntax errors
- `ruff check agent/lsp/cli.py agent/curator.py` — all checks passed
- No functional logic changed; only removed inert assignments