### PR TITLE
修复：移除用户注册接口中调试用的print语句

### DIFF
--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -1,8 +1,11 @@
 from fastapi import APIRouter, Form, Depends, HTTPException, status, Request, UploadFile, File
 from datetime import datetime, timedelta
+import logging
 from app.dependencies import check_jwt_token, get_db, verify_password, get_password_hash, require_admin
 from app.config import settings
 from jose import jwt
+
+logger = logging.getLogger(__name__)
 import requests
 import os
 import json
@@ -250,9 +253,9 @@ async def register(request: Request, name: str = Form(...), password: str = Form
             detail=error_msg
         )
     
-    print(name, email)
+    logger.debug("用户注册: name=%s, email=%s", name, email)
     form_data = await request.form()
-    print(form_data.get("phone"))
+    logger.debug("注册手机号: %s", form_data.get("phone"))
     # 检查手机号是否已注册
     existing_user = db.query(Users).filter(Users.phone == phone).first()
     existing_register = db.query(Register).filter(Register.phone == phone).first()


### PR DESCRIPTION
## 修改说明

移除用户注册接口中遗留的 print 调试语句，改用 logging 模块输出，保持与项目其他模块一致的日志规范。

### 修改内容

1. **tm-backend/app/routers/users.py**
   - 添加 `import logging` 和 `logger = logging.getLogger(__name__)`
   - 将 `print(name, email)` 替换为 `logger.debug("用户注册: name=%s, email=%s", name, email)`
   - 将 `print(form_data.get("phone"))` 替换为 `logger.debug("注册手机号: %s", form_data.get("phone"))`

### 验证

- Python 语法检查通过（py_compile 验证）
- 使用 logging 模块，与 main.py 已配置的日志格式一致
- 仅替换调试输出语句，不影响注册业务逻辑
- 修改范围精准（5行改动），符合项目编码规范