### PR TITLE
修复：移除用户注册接口中调试用的print语句

### DIFF
--- a/tm-backend/app/routers/users.py
+++ b/tm-backend/app/routers/users.py
@@ -250,9 +250,7 @@ async def register(request: Request, name: str = Form(...), password: str = Form
             detail=error_msg
         )
     
-    print(name, email)
-    form_data = await request.form()
-    print(form_data.get("phone"))
+    await request.form()
     # 检查手机号是否已注册
     existing_user = db.query(Users).filter(Users.phone == phone).first()
     existing_register = db.query(Register).filter(Register.phone == phone).first()


### PR DESCRIPTION
## 修复内容

移除用户注册接口 `POST /api/users/register` 中调试遗留的 print 语句：
- 删除 `print(name, email)` 调试输出
- 删除 `print(form_data.get("phone"))` 调试输出

## 修复文件

- `tm-backend/app/routers/users.py`：移除注册接口中的两处 print 语句

## 验证

- Python 语法检查通过（py_compile）
- ruff lint 检查无新增问题

修复#29（关联 TypeScript 出题专家 Prompt Issue 中的调试代码清理需求）