### PR TITLE
修复：补充statistics.py缺失的logging模块导入

### DIFF
--- a/tm-backend/app/routers/statistics.py
+++ b/tm-backend/app/routers/statistics.py
@@ -5,9 +5,12 @@ from datetime import datetime, timedelta
 from typing import Optional, List
 import os
 import ast
+import logging
 
 from app.dependencies import check_jwt_token, get_db, require_admin
 from app.core.schemas.users import TokenModel
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/statistics", tags=["statistics"])
 


### PR DESCRIPTION
## 修复内容

补充 `tm-backend/app/routers/statistics.py` 中缺失的 `logging` 模块导入。

`read_user_file` 函数中使用了 `logger.warning()`，但文件头部未导入 `logging` 模块，导致运行时会出现 `NameError: name 'logger' is not defined`。

## 修复文件

- `tm-backend/app/routers/statistics.py`：添加 `import logging` 和 `logger = logging.getLogger(__name__)`