### PR TITLE
修复：JWT decode的algorithms参数改为列表格式

### DIFF
--- a/tm-backend/app/dependencies.py
+++ b/tm-backend/app/dependencies.py
@@ -47,7 +47,7 @@ def check_jwt_token(token: Optional[str] = Header(""), db: Session = Depends(get
     :return: 返回用户信息
     """
     try:
-        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=settings.ALGORITHM)
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
         id: str = payload.get("sub")
         # 得到令牌过期时间
         expiration_timestamp = payload.get("exp")


### PR DESCRIPTION
## 修改说明

JWT token 解码时 `algorithms` 参数应为列表类型，当前代码传递的是字符串。

python-jose 的 `jwt.decode()` 要求 `algorithms` 参数为 `list[str]`，传入单个字符串虽然部分版本能工作，但不符合 API 规范，且在未来版本中可能导致类型错误。

## 修改内容

- `tm-backend/app/dependencies.py`：将 `algorithms=settings.ALGORITHM` 改为 `algorithms=[settings.ALGORITHM]`

## 验证

- 本地语法校验通过（`py_compile`）
