### PR TITLE
修复：Pydantic Schema字段类型注解和默认值规范化

### DIFF
--- a/tm-backend/app/core/schemas/users.py
+++ b/tm-backend/app/core/schemas/users.py
@@ -2,8 +2,8 @@ from typing import Optional
 from pydantic import BaseModel, EmailStr
 
 class UserBase(BaseModel):
-    id: Optional[int] = False
-    username: str = None
+    id: Optional[int] = None
+    username: Optional[str] = None
     # pip install pydantic[email] 使用email验证的时候需要增加这个库
     email: Optional[EmailStr] = None
     role: Optional[str] = 'user'
@@ -12,12 +12,12 @@ class UserBase(BaseModel):
         from_attributes = True
 
 class TokenModel(UserBase):
-    atoken: str = None
-    rtoken: str = None
+    atoken: Optional[str] = None
+    rtoken: Optional[str] = None
 
 class LoginModel(BaseModel):
-    phone: str = None
-    password: str = None
+    phone: Optional[str] = None
+    password: Optional[str] = None
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
## 修改说明

Pydantic Schema 中多个字段类型注解不规范，存在以下问题：

1. `id: Optional[int] = False` — 默认值应为 `None` 而非 `False`
2. `username: str = None` — 类型应标注为 `Optional[str]`
3. `atoken: str = None`、`rtoken: str = None` — 同上
4. `phone: str = None`、`password: str = None` — 同上

这些字段在 Pydantic v2 严格模式下会导致类型校验错误。

## 修改内容

- `tm-backend/app/core/schemas/users.py`：
  - `id` 默认值从 `False` 改为 `None`
  - 所有默认值为 `None` 的字段统一标注为 `Optional[str] = None`

## 验证

- 本地语法校验通过（`py_compile`）
