### PR TITLE
修复：inno路由所有端点添加JWT身份验证

### DIFF
--- a/tm-backend/app/routers/inno.py
+++ b/tm-backend/app/routers/inno.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Form, Depends, HTTPException, status, Request
 from datetime import datetime, timedelta
 from app.dependencies import check_jwt_token, get_db
 from sqlalchemy.orm import Session
-from app.core.schemas.users import UserBase
+from app.core.schemas.users import TokenModel
 from app.core.models.users import Users, Base
 from app.database import engine
 import json, os, ast
@@ -21,7 +21,9 @@ inno = APIRouter(
 
 
 @inno.get('/get_tm/{user_id}')
-async def get_tm(user_id:int):
+async def get_tm(user_id: int, user: Users = Depends(check_jwt_token)):
+    if user_id != user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="无权访问其他用户数据")
     userid = str(user_id)
     pr = []
     fn = []
@@ -37,7 +39,9 @@ async def get_tm(user_id:int):
     return {"pr":pr, "fn":fn}
 
 @inno.get('/get_pr/{user_id}')
-async def get_pr(user_id:int):
+async def get_pr(user_id: int, user: Users = Depends(check_jwt_token)):
+    if user_id != user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="无权访问其他用户数据")
     userid = str(user_id)
     pr = []
     if os.path.exists(f"static/tm/t{userid}.txt"):
@@ -47,7 +51,9 @@ async def get_pr(user_id:int):
     return pr
 
 @inno.put('/save_pr/{user_id}')
-async def save_pr(request: Request, user_id:int):
+async def save_pr(request: Request, user_id: int, user: Users = Depends(check_jwt_token)):
+    if user_id != user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="无权访问其他用户数据")
     userid = str(user_id)
     form_data = await request.form()
     # 尝试多种参数格式
@@ -60,7 +66,9 @@ async def save_pr(request: Request, user_id:int):
     return {"code": "200"}
 
 @inno.put('/finish_tm/{user_id}')
-async def finish_tm(request: Request, user_id:int):
+async def finish_tm(request: Request, user_id: int, user: Users = Depends(check_jwt_token)):
+    if user_id != user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="无权访问其他用户数据")
     userid = str(user_id)
     form_data = await request.form()
     # 尝试多种参数格式
@@ -75,8 +83,10 @@ async def finish_tm(request: Request, user_id:int):
 
 
 @inno.post('/add_study_time/{user_id}')
-async def add_study_time(request: Request, user_id:int):
+async def add_study_time(request: Request, user_id: int, user: Users = Depends(check_jwt_token)):
     """添加学习时间到时间管理"""
+    if user_id != user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="无权访问其他用户数据")
     userid = str(user_id)
     try:
         content_type = request.headers.get("content-type", "")
@@ -104,6 +114,8 @@ async def add_study_time(request: Request, user_id:int):
                         tasklist_str = parsed['taskinfo'][0]
                         tasklist = json.loads(tasklist_str)
                 except Exception as parse_err:
+                    import logging
+                    logger = logging.getLogger(__name__)
                     logger.warning("URL解析错误: %s", parse_err)
 
         # 读取现有数据


### PR DESCRIPTION
## 修改说明

`/api/inno/` 路由下的 5 个端点（`get_tm`、`get_pr`、`save_pr`、`finish_tm`、`add_study_time`）均无身份验证，任何人可以通过传入任意 `user_id` 读写其他用户的时间管理数据。

## 修改内容

- 为所有 5 个端点添加 `user: Users = Depends(check_jwt_token)` 认证依赖
- 每个端点增加 `user_id != user.id` 校验，确保用户只能访问自己的数据
- 修复 `add_study_time` 中 `logger` 未定义的问题（运行时会抛出 NameError）
- 修正 import：将未使用的 `UserBase` 替换为 `TokenModel`

## 验证

- 本地语法校验通过（`py_compile`）
