### PR TITLE
修复#127：TypeScript教程条件语句中注释符号错误

### DIFF
--- a/tutorial/TypeScript/第2章-ts控制语句/Typescript教程2.1-条件语句.md
+++ b/tutorial/TypeScript/第2章-ts控制语句/Typescript教程2.1-条件语句.md
@@ -20,7 +20,7 @@ TypeScript if 语句由一个布尔表达式后跟一个或多个语句组成。
 语法格式如下所示：
 ```typescript
 if(boolean_expression){
-    # 在布尔表达式 boolean_expression 为 true 执行
+    // 在布尔表达式 boolean_expression 为 true 执行
 }
 
 ```
@@ -42,9 +42,9 @@ if (num > 0) {
 
 ```typescript
 if(boolean_expression){
-   # 在布尔表达式 boolean_expression 为 true 执行
+   // 在布尔表达式 boolean_expression 为 true 执行
 }else{
-   # 在布尔表达式 boolean_expression 为 false 执行
+   // 在布尔表达式 boolean_expression 为 false 执行
 }
 ```
 
@@ -66,13 +66,13 @@ if...else if....else 语句在执行多个判断条件的时候很有用。
 
 ```typescript
 if(boolean_expression 1) {
-    # 在布尔表达式 boolean_expression 1 为 true 执行
+    // 在布尔表达式 boolean_expression 1 为 true 执行
 } else if( boolean_expression 2) {
-    # 在布尔表达式 boolean_expression 2 为 true 执行
+    // 在布尔表达式 boolean_expression 2 为 true 执行
 } else if( boolean_expression 3) {
-    # 在布尔表达式 boolean_expression 3 为 true 执行
+    // 在布尔表达式 boolean_expression 3 为 true 执行
 } else {
-    # 布尔表达式的条件都为 false 时执行
+    // 布尔表达式的条件都为 false 时执行
 }
 ```
 


### PR DESCRIPTION
修复#127：TypeScript教程条件语句中注释符号错误

## 问题

在 `Typescript教程2.1-条件语句.md` 中，if/else 语法示例的 TypeScript 代码块内误用了 Python 风格的注释符号 `#`，应使用 TypeScript/JavaScript 风格的 `//`。学习者按示例粘贴到 TypeScript 编译器会报语法错误。

## 修改内容

将以下 7 处 TypeScript 代码块中的注释符号由 `#` 更正为 `//`：

1. `if` 语句示例中的注释
2. `if...else` 语句示例中的 2 处注释（true 分支和 false 分支）
3. `if...else if...else` 语句示例中的 4 处注释（3 个 else if 分支与 1 个 else 分支）

涉及文件：
- `tutorial/TypeScript/第2章-ts控制语句/Typescript教程2.1-条件语句.md`

## 验证

- 已确认 7 处修改全部命中，无遗漏
- 修改后再次扫描 TypeScript 代码块，无残留 `#` 注释
- 改动仅限注释符号，未涉及任何代码逻辑或控制流
- 其余 TypeScript 教程章节未发现同类问题

修复 #127
