### PR TITLE
修复：PersonalDashboard.vue缺少ElMessage导入导致catch块静默失败

### DIFF
--- a/tm-frontend/src/views/statistics/PersonalDashboard.vue
+++ b/tm-frontend/src/views/statistics/PersonalDashboard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
 import { useLoginStore } from '../../store'
+import { ElMessage } from 'element-plus'
 import {
     fetchPersonalOverviewAPI,
     fetchPersonalTrendAPI,


### PR DESCRIPTION
## 修改说明

`tm-frontend/src/views/statistics/PersonalDashboard.vue` 在 `fetchPersonalDashboardData` 的 catch 块中调用了 `ElMessage.error('获取统计数据失败')`，但顶部 import 区未引入 `ElMessage`。

实际触发链路：
- 任意子接口（fetchPersonalOverviewAPI / fetchPersonalTrendAPI / fetchShuzhiHistoryAPI / fetchTimeDistributionAPI）抛错 → 进入 catch
- 模板渲染阶段 Vue 解析 `<script setup>` 引用，`ElMessage` 为 `undefined` → `ElMessage.error is not a function`
- 结果：用户既看不到错误提示，控制台也不输出（catch 块直接抛 ReferenceError）

本次修复仅新增一行 `import { ElMessage } from 'element-plus'`，与同目录下其他统计页面（GlobalDashboard.vue、UserAnalysis.vue）的 import 风格保持一致。

## 验证

- 本地审查：PersonalDashboard.vue 中其他 import 风格统一、`ElMessage` 使用位置（line 78）现已正确解析
- 类型层面：项目 `tsconfig.json` 启用 strict 模式，未导入即使用本来应被 tsc 报错；补 import 后消除潜在编译失败
- 影响面：仅修改 `PersonalDashboard.vue`，1 行新增，0 行删除

## 关联背景

本仓库近 75 个 open PR 中已有多个修复其他 .vue 文件缺失 import 的同类问题（如 PR #91 修复 All.vue 缺失 computed 导入），本次针对 PersonalDashboard.vue 的相同问题补齐。