### PR TITLE
修复：第22课FastAPI天气查询MCP教程图片链接中的%20编码

### DIFF
--- a/tutorial/FastAPI/md版本/第22课-实现天气查询 MCP.md
+++ b/tutorial/FastAPI/md版本/第22课-实现天气查询 MCP.md
@@ -7,21 +7,21 @@
 > 🎁 教程代码中已经配置好了天气服务 API，如无法使用请自行注册或使用其他天气服务。
 
 - 访问[https://id.qweather.com/](https://id.qweather.com/) 注册账号,初次使用需绑定手机号和邮箱。
-![注册和风天气开发账号](../第6章-FastAPI%20MCP/images/01-注册和风天气开发账号.png)
+![注册和风天气开发账号](../第6章-FastAPI MCP/images/01-注册和风天气开发账号.png)
 
 - 注册成功后，点击菜单中的 `开发服务控制台`，进入开发控制台。
-![进入开发服务控制台](../第6章-FastAPI%20MCP/images/02-进入开发服务控制台.png)
+![进入开发服务控制台](../第6章-FastAPI MCP/images/02-进入开发服务控制台.png)
 
 - 点击`项目管理`-`创建项目`，创建一个项目，如 `fastapi`， 创建之后此步骤获得**PROJECT_ID**。
-![创建项目](../第6章-FastAPI%20MCP/images/03-创建项目.png)
-![获得PROJECT_ID](../第6章-FastAPI%20MCP/images/03-获得PROJECT_ID.png)
+![创建项目](../第6章-FastAPI MCP/images/03-创建项目.png)
+![获得PROJECT_ID](../第6章-FastAPI MCP/images/03-获得PROJECT_ID.png)
 
 - 点击项目如`fastapi`，进入项目详情页并点击`创建凭据`开始创建 JWT 凭据，需先在本地生成公私钥对再创建，创建之后此步骤获得**PRIVATE_KEY**和**KEY_ID**。（PS: 虽然 APIKey 更简单，但推荐使用JSON Web Token (JWT)的认证方式获得更高等级的安全性以及不受限的API请求）
-![创建JWT凭据](../第6章-FastAPI%20MCP/images/04-创建JWT凭据.png)
-![获得KEY_ID](../第6章-FastAPI%20MCP/images/04-获得KEY_ID.png)
+![创建JWT凭据](../第6章-FastAPI MCP/images/04-创建JWT凭据.png)
+![获得KEY_ID](../第6章-FastAPI MCP/images/04-获得KEY_ID.png)
 
 - 点击`设置`, 从开发者信息中获取 API Host，也就是**WEATHER_API_HOST**
-![获得WEATHER_API_HOST](../第6章-FastAPI%20MCP/images/05-获得WEATHER_API_HOST.png)
+![获得WEATHER_API_HOST](../第6章-FastAPI MCP/images/05-获得WEATHER_API_HOST.png)
 
 至此，我们天气查询 MCP 中需要用到的配置信息已经全部获取。
 
@@ -30,7 +30,7 @@
 > 🔧 选用你使用最多的 MCP 客户端即可，此处仅作参考
 
 从 [Cherry Studio](https://cherry-studio.com) 安装 MCP 客户端，并配置好模型服务。
-![安装配置Cherry Studio](../第6章-FastAPI%20MCP/images/06-安装配置Cherry%20Studio.png)
+![安装配置Cherry Studio](../第6章-FastAPI MCP/images/06-安装配置Cherry Studio.png)
 
 ## 代码编写
 
@@ -392,7 +392,7 @@ python main.py
 ```
 
 然后，你可以使用浏览器访问 `http://localhost:8009/docs` 来查看并测试API。
-![FastAPI docs测试](../第6章-FastAPI%20MCP/images/07-FastAPI%20docs测试.png)
+![FastAPI docs测试](../第6章-FastAPI MCP/images/07-FastAPI docs测试.png)
 
 借着在 Cherry Studio 中配置好的 MCP 服务，我们可以直接在 MCP 客户端中使用 `get_weather_by_city` 接口:
 
@@ -401,18 +401,18 @@ python main.py
 - URL：`http://localhost:8009/mcp`
 - 请求头：`Authorization=Bearer zishu.co`
 
-![配置 MCP](../第6章-FastAPI%20MCP/images/08-配置MCP.png)
+![配置 MCP](../第6章-FastAPI MCP/images/08-配置MCP.png)
 
 在`工具`中，我们可以看到`get_weather_by_city`接口已经添加到MCP服务中。
-![MCP Tool](../第6章-FastAPI%20MCP/images/08-MCP%20Tool.png)
+![MCP Tool](../第6章-FastAPI MCP/images/08-MCP Tool.png)
 
 新建一个话题，先不开启 MCP 服务器设置，直接输入`广州天气怎么样`，我们会发现大模型无法实时获取天气。
-![大模型无法获取实时天气](../第6章-FastAPI%20MCP/images/09-没有MCP的情况.png)
+![大模型无法获取实时天气](../第6章-FastAPI MCP/images/09-没有MCP的情况.png)
 
 接着我们启用 MCP 服务，并输入`广州天气怎么样`，我们会发现大模型可以实时获取天气。`get_weather_by_city` tool 被成功调用，并返回了天气信息。
-![MCP 调用成功](../第6章-FastAPI%20MCP/images/09-MCP调用成功.png)
+![MCP 调用成功](../第6章-FastAPI MCP/images/09-MCP调用成功.png)
 
 当然，大模型每次的回答都是随机的，这是因为我们的程序并没有限制大模型的回答格式，不过结果是完全正确的。
-![MCP 调用成功](../第6章-FastAPI%20MCP/images/09-MCP调用成功重复.png)
+![MCP 调用成功](../第6章-FastAPI MCP/images/09-MCP调用成功重复.png)
 
 如果想要拓展更多功能，你可以动手试试看！


### PR DESCRIPTION
## 修改内容

`tutorial/FastAPI/md版本/第22课-实现天气查询 MCP.md` 文件中的图片链接使用了 `%20` URL 编码指向目录和文件名，但实际目录 `tutorial/FastAPI/第6章-FastAPI MCP/images/` 下的文件名是含中文和空格的纯文本，导致 GitHub 渲染时全部 14 张配图无法显示。

具体问题：
- 目录路径 `../第6章-FastAPI%20MCP/images/` 中的 `%20` 应为字面空格（11 处）
- 文件名 `06-安装配置Cherry%20Studio.png` / `07-FastAPI%20docs测试.png` / `08-MCP%20Tool.png` 中的 `%20` 应为字面空格（3 处）

合计 14 处替换，将所有 `%20` 还原为字面空格字符。

## 验证

- 本地 Python 脚本扫描文件中全部 14 处 `![...](...)` 图片引用，重新计算相对路径，全部 14 个目标文件存在于 `tutorial/FastAPI/第6章-FastAPI MCP/images/` 目录
- `grep -c '%20'` 在文件中的剩余次数为 0，确认无遗漏
- `git diff` 确认变更仅为字面 `%20` ↔ 空格，无任何其他字符改动

## 影响范围

仅修改 1 个 Markdown 文件，14 行替换；不影响任何代码、配置或运行时行为；不破坏现有渲染器（GitHub、VSCode、其他 Markdown 解析器对字面空格和 `%20` 在本地相对路径上的处理一致，本仓库所有其他教程目录均使用字面空格）。

## 测试建议

- 提交后在 GitHub 上浏览该 Markdown 文件，确认 14 张配图全部正确显示
- 对照 `tutorial/FastAPI/第6章-FastAPI MCP/images/` 目录中实际文件名，确认链接一一对应
