### PR TITLE
优化：将代码执行器的动态import改为静态import

### DIFF
--- a/tm-frontend/src/components/code-editor/InlineCodeRunner.vue
+++ b/tm-frontend/src/components/code-editor/InlineCodeRunner.vue
@@ -4,6 +4,7 @@ import MonacoEditor from './MonacoEditor.vue'
 import ExecutionResult from './ExecutionResult.vue'
 import type { ExecutionOutput } from './ExecutionResult.vue'
 import { SUPPORTED_LANGUAGES, normalizeLanguage } from '@/utils/languageMapping'
+import { executeCode } from '@/composables/useCodeExecution'
 
 interface Props {
   code: string
@@ -57,7 +58,6 @@ const runCode = async () => {
   output.value = null
 
   try {
-    const { executeCode } = await import('@/composables/useCodeExecution')
     output.value = await executeCode(selectedLanguage.value, localCode.value)
   } catch (error: any) {
     output.value = {


### PR DESCRIPTION
## 背景

`InlineCodeRunner.vue` 在每次用户点击"运行"按钮时，都执行一次 `await import('@/composables/useCodeExecution')`。该模块不属于需要延迟加载的体积庞大的代码片段，而是普通工具函数，引入该模块的代价远小于动态导入本身的开销。

## 修改

- 在 `<script setup>` 顶部增加 `import { executeCode } from '@/composables/useCodeExecution'`
- `runCode()` 中删除动态导入语句，直接调用 `executeCode(...)`

## 收益

- 编译期模块依赖清晰，符合 ESM 标准用法
- 每次点击运行省去一次动态模块加载开销
- Vite 打包时能正确进行 tree-shaking，不再额外产生异步 chunk

## 验证

- TypeScript 类型一致：`executeCode(language: string, code: string)` 参数签名未变
- 仅修改一个文件 `tm-frontend/src/components/code-editor/InlineCodeRunner.vue`
- 静态 import 路径与原动态路径一致，不存在循环依赖风险
