### PR TITLE
修复：dependencies.py 和 tutorial.py 中 except 子句 raise 添加 from e 异常链

### DIFF
--- a/tm-backend/app/dependencies.py
+++ b/tm-backend/app/dependencies.py
@@ -57,7 +57,7 @@ def check_jwt_token(token: Optional[str] = Header(""), db: Session = Depends(get
         # 通过解析得到的username,获取用户信息,并返回
         # return users_db.get(username)
         return db.query(users.Users).filter(users.Users.id== int(id)).first()
-    except (JWTError, ValidationError):
+    except (JWTError, ValidationError) as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail={
@@ -65,7 +65,7 @@ def check_jwt_token(token: Optional[str] = Header(""), db: Session = Depends(get
                 'message': "Token Error",
                 'data': "Token Error",
             }
-        )
+        ) from e
 
 
 def require_admin(user: users.Users = Depends(check_jwt_token)):

--- a/tm-backend/app/routers/tutorial.py
+++ b/tm-backend/app/routers/tutorial.py
@@ -117,7 +117,7 @@ def read_tutorial_file(file_path: str) -> str:
         with open(full_path, 'r', encoding='utf-8') as f:
             return f.read()
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"读取文件失败: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"读取文件失败: {str(e)}") from e
 
 
 @router.get("/courses")


### PR DESCRIPTION
## 修复内容

对 `tm-backend/app/dependencies.py` 和 `tm-backend/app/routers/tutorial.py` 中 except 子句内的 raise 语句补充 `from e` 异常链。

## 修改详情

| 文件 | 行 | 修改 |
|------|-----|------|
| `tm-backend/app/dependencies.py` | 60-68 | `except (JWTError, ValidationError)` → `except (JWTError, ValidationError) as e`；raise 添加 `from e` |
| `tm-backend/app/routers/tutorial.py` | 119-120 | raise 添加 `from e`（已有 `as e`） |

## 背景

之前 PR #134 已经修复了 `users.py` 中 19 处同类 B904 违规，本 PR 处理剩余两处：

- `dependencies.py:60` — `check_jwt_token` 的 JWT 解析异常处理，缺少 `as e` + `from e`
- `tutorial.py:119` — `read_tutorial_file` 的文件读取异常处理，已有 `as e`，仅缺 `from e`

## 收益

保留 Python 异常链（`__cause__` 属性），便于日志聚合时定位根因，与 `users.py` 的修复风格保持一致。

## 验证

- `python3 -m py_compile` 通过
- `ruff check --select B904` 通过（原 2 处错误现已清零）
- `ruff check --select F821` 通过（确认无 `Undefined name 'e'` 引入）
- 回归测试：`HTTPException.__cause__` 在两种场景下均被正确设置
- FastAPI 应用可正常导入 `dependencies` 和 `routers.tutorial`