### PR TITLE
修复：移除 ruff 警告 F841 与 B904 各一处

### DIFF
--- a/tm-backend/app/routers/config.py
+++ b/tm-backend/app/routers/config.py
@@ -77,7 +77,7 @@ async def save_configs(
         }
     except Exception as e:
         db.rollback()
-        raise HTTPException(status_code=500, detail=f"保存失败: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"保存失败: {str(e)}") from e
 
 
 @router.get("/check-inactive")

--- a/tm-backend/app/services/python_executor.py
+++ b/tm-backend/app/services/python_executor.py
@@ -84,8 +84,6 @@ e = math.e
         Returns:
             (is_safe, error_message)
         """
-        code_lower = code.lower()
-
         # 检查禁止的模式
         for pattern in self.FORBIDDEN_PATTERNS:
             if re.search(pattern, code, re.IGNORECASE):


### PR DESCRIPTION
## 修改说明

`ruff check app/ --select F841,B904` 在以下位置仍有未覆盖的警告，本 PR 收尾处理。

| 文件 | 行 | 类型 | 问题 |
|------|-----|------|------|
| `tm-backend/app/services/python_executor.py` | 87 | F841 | `code_lower = code.lower()` 局部变量从未被读取 |
| `tm-backend/app/routers/config.py` | 80 | B904 | `raise HTTPException(...)` 在 `except` 子句内，缺少 `from e` 异常链 |

## 详细说明

### `app/services/python_executor.py` — 删除未使用的 `code_lower`

`_is_safe_code` 方法在函数开头将 `code` 转小写后赋值给 `code_lower`，但函数体后续逻辑（`re.search(pattern, code, re.IGNORECASE)`、`code.split('\n')`）全部直接使用原 `code` 变量，`code_lower` 始终未被读取。

```python
# 修改前
code_lower = code.lower()

# 检查禁止的模式
for pattern in self.FORBIDDEN_PATTERNS:
    if re.search(pattern, code, re.IGNORECASE):
```

`re.IGNORECASE` 已保证大小写不敏感匹配，`code_lower` 属于冗余赋值，直接删除即可。

### `app/routers/config.py` — 补充 `from e` 异常链

`save_configs` 接口的异常处理在 `except Exception as e` 内直接 `raise HTTPException(...)`，未保留对原始异常的回溯链。补 `from e` 后，原始异常会出现在 `HTTPException.__cause__` 中，便于日志聚合与 Sentry 类工具定位根因。

```python
# 修改前
except Exception as e:
    db.rollback()
    raise HTTPException(status_code=500, detail=f"保存失败: {str(e)}")

# 修改后
except Exception as e:
    db.rollback()
    raise HTTPException(status_code=500, detail=f"保存失败: {str(e)}") from e
```

## 验证

- `python3 -m py_compile app/services/python_executor.py app/routers/config.py` 通过
- `ruff check app/ --select F841` 关于 `code_lower` 的报告清零
- `ruff check app/ --select B904` 关于 `config.py:80` 的报告清零
- `ruff check app/ --select F821` 通过（无 `Undefined name 'e'`）
- AST 解析两个文件均无语法错误
- 不影响任何接口契约、状态码或错误信息

## 范围

仅 2 个文件、3 行变更（1 处删除、1 处删除、1 处追加），与既有的 #133（清理后端 F841 + 死代码）和 #135（dependencies/tutorial 的 B904）属于同一系列工作，互补收尾。
