### PR TITLE
fix: Docker 回退到 subprocess 时丢失预导入模块

### DIFF
--- a/tm-backend/app/services/python_executor.py
+++ b/tm-backend/app/services/python_executor.py
@@ -6,9 +6,12 @@ import asyncio
 import re
 import sys
 import platform
+import logging
 from typing import Dict, Any
 import subprocess
 import shlex
+
+logger = logging.getLogger(__name__)
 
 
 class PythonExecutor:
@@ -174,8 +177,9 @@ e = math.e
                 'exitCode': -1
             }
         except Exception as e:
-            # Docker 不可用，回退到 subprocess 方式（注意：full_code 已在上面构造）
-            return self._execute_with_subprocess(code, timeout)
+            # Docker 不可用，回退到 subprocess 方式（需要使用 full_code，保留预导入模块）
+            logger.warning("Docker 不可用，回退到 subprocess: %s", e)
+            return self._execute_with_subprocess(full_code, timeout)
 
     def _execute_with_subprocess(self, code: str, timeout: int) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## 修复说明

`PythonExecutor._execute_with_docker` 在最外层 `except Exception` 分支回退到 `_execute_with_subprocess` 时，传入了原始 `code`，而不是已经拼接好预导入模块的 `full_code`。

这会导致：当 Docker SDK 调用过程中抛出未被 `docker.errors.*` 捕获的异常时，回退路径上的用户代码如果使用了 `Counter` / `defaultdict` / `reduce` / `pd` / `np` 等 `PREIMPORTED_MODULES` 中预导入的符号，就会出现 `NameError`。

## 改动

- 补全 `logging` 模块导入与模块级 `logger` 定义
- 回退分支改为转发 `full_code`，与 `_execute_with_subprocess` 内部拼接逻辑保持一致
- 增加 warning 日志，便于运维定位 Docker 不可用事件

## 验证

- `py_compile` 通过
- 自定义脚本断言源码已修改，并模拟 PREIMPORTED_MODULES + 用户代码拼接执行 `Counter(['a','b','a'])`，输出符合预期
- 改动 6 行新增 / 2 行删除，影响面仅限 docker 回退路径

## 兼容性

不影响 Docker 可用时的正常路径；仅在异常回退路径下修复预导入符号丢失问题。