### PR TITLE
fix(study): 通过sendBeacon在页面离开时自动申报学习时长

### DIFF
--- a/tm-frontend/src/views/Study.vue
+++ b/tm-frontend/src/views/Study.vue
@@ -288,9 +288,20 @@ const submitReport = async () => {
 
 // 页面离开时自动申报
 const beforeUnload = () => {
-  if (studyTimer.value > 60) {
-    // 实际项目中这里可以发送请求
-    console.log('学习时长:', studyTimer.value)
+  if (studyTimer.value > 60 && course.value) {
+    const userId = Number(loginstate.id)
+    if (!userId) return
+
+    const minutes = Math.ceil(studyTimer.value / 60)
+
+    // 使用 navigator.sendBeacon 确保请求在页面卸载时仍能发出
+    // 后端 report-study-time 接收表单数据，使用 FormData 编码
+    const formData = new FormData()
+    formData.append('user_id', String(userId))
+    formData.append('course_name', course.value.name)
+    formData.append('lesson_title', currentTitle.value)
+    formData.append('duration', String(minutes))
+    navigator.sendBeacon('/api/tutorial/report-study-time', formData)
   }
 }
 


### PR DESCRIPTION
## 修复说明

`Study.vue` 页面中的 `beforeUnload` 处理函数原本只调用 `console.log`，没有真正把学习时长上报到后端。这次把它改为通过 `navigator.sendBeacon` 发送 `FormData` 编码的请求到 `/api/tutorial/report-study-time`，在用户关闭、刷新或路由跳转页面时自动完成申报。

## 变更内容

- 复用已有的 `course`、`currentTitle`、`loginstate` 状态
- `studyTimer` 超过 60 秒才触发，避免噪声请求
- 使用 `FormData` 编码，与后端 `@router.post("/report-study-time")` 的 `Form(...)` 参数对齐
- 使用 `navigator.sendBeacon` 替代 `fetch`，确保在 `beforeunload` 期间请求能稳定发出
- 加入 `userId` 与 `course.value` 判空守卫，避免未登录/未加载课程时打空请求

## 影响范围

仅 `tm-frontend/src/views/Study.vue` 的 `beforeUnload` 函数，14 行新增 / 3 行删除。其他逻辑保持不变。
