### PR TITLE
优化：inno路由文件读取对损坏行增加容错处理

### DIFF
--- a/tm-backend/app/routers/inno.py
+++ b/tm-backend/app/routers/inno.py
@@ -20,6 +20,21 @@ inno = APIRouter(
 )
 
 
+def _safe_literal_eval_lines(lines):
+    """对文件行序列执行 ast.literal_eval，遇到无法解析的行跳过并记录日志"""
+    result = []
+    for line in lines:
+        line = line.strip() if isinstance(line, str) else line
+        if not line:
+            continue
+        try:
+            result.append(ast.literal_eval(line))
+        except (ValueError, SyntaxError):
+            logger.warning("跳过无法解析的行: %r", line[:80])
+            continue
+    return result
+
+
 @inno.get('/get_tm/{user_id}')
 async def get_tm(user_id:int):
     userid = str(user_id)
@@ -28,11 +43,11 @@ async def get_tm(user_id:int):
     if os.path.exists(f"static/tm/t{userid}.txt"):
         with open(f"static/tm/t{userid}.txt", "r", encoding="utf-8") as f:
             pr=f.readlines()
-    pr = [ast.literal_eval(x) for x in pr]
+    pr = _safe_literal_eval_lines(pr)
     if os.path.exists(f"static/tm/f{userid}.txt"):
         with open(f"static/tm/f{userid}.txt", "r", encoding="utf-8") as f:
             fn=f.readlines()
-    fn = [ast.literal_eval(x) for x in fn]
+    fn = _safe_literal_eval_lines(fn)
     fn.reverse()
     return {"pr":pr, "fn":fn}
 
@@ -43,7 +58,7 @@ async def get_pr(user_id:int):
     if os.path.exists(f"static/tm/t{userid}.txt"):
         with open(f"static/tm/t{userid}.txt", "r", encoding="utf-8") as f:
             pr=f.readlines()
-    pr = [ast.literal_eval(x) for x in pr]
+    pr = _safe_literal_eval_lines(pr)
     return pr
 
 @inno.put('/save_pr/{user_id}')


### PR DESCRIPTION
## 优化说明

`/api/inno/get_tm/{user_id}` 和 `/api/inno/get_pr/{user_id}` 在读取 `static/tm/t{userid}.txt`、`static/tm/f{userid}.txt` 时使用裸的 `[ast.literal_eval(x) for x in lines]`。如果文件中有任何一行因写入中断、并发覆盖或编码错误导致 `ast.literal_eval` 抛 `ValueError` / `SyntaxError`，整个接口会返回 500，用户的时间管理数据就完全无法访问。

`add_study_time` 已经使用相同的容错模式（line 121）。本次改动把另外三处裸调用统一收敛到新增的 `_safe_literal_eval_lines` 辅助函数：解析失败的行通过 `logger.warning` 记录后跳过，合法行正常返回。

## 行为差异

- 合法文件：与原行为完全一致
- 含损坏行的文件：跳过损坏行，返回剩余合法行（之前会 500）
- 空文件 / 全损坏：返回 `[]`（之前会 500）

## 验证

`py_compile` 通过。`/tmp/test_inno_safe_parse.py` 覆盖五种情况：

1. 全部合法输入全部解析
2. 损坏行被跳过，合法行保留
3. 空输入返回空列表
4. 全部损坏返回空列表
5. 合法输入与原裸 `ast.literal_eval` 行为等价

并通过 git-stash 三步验证：原代码在损坏行上抛 `SyntaxError`，新代码正常返回。
