### PR TITLE
fix(deps): check_jwt_token 校验缺失 sub 声明的 token 返回 401

### DIFF
--- a/tm-backend/app/dependencies.py
+++ b/tm-backend/app/dependencies.py
@@ -49,6 +49,11 @@ def check_jwt_token(token: Optional[str] = Header(""), db: Session = Depends(get
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=settings.ALGORITHM)
         id: str = payload.get("sub")
+        if id is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail={'code': 5000, 'message': "Token Error", 'data': "Token Error"},
+            )
         # 得到令牌过期时间
         expiration_timestamp = payload.get("exp")
         # 把令牌过期时间转化为人类可读时间信息


### PR DESCRIPTION
## 修复说明

`check_jwt_token` 在解码成功后直接调用 `int(id)` 把 `payload["sub"]` 转成用户 ID。如果客户端（无论是 bug 还是攻击）发来一个签名正确但 `sub` 声明为缺失的 token，`payload.get("sub")` 会返回 `None`，`int(None)` 抛 `TypeError`，最终导致接口返回 500 而不是 401。

由于同函数内的 `except` 子句只捕获 `(JWTError, ValidationError)`，`TypeError` 会冒泡，调用方拿到的是未预期的服务端错误。

## 修改范围

`tm-backend/app/dependencies.py` 第 49-54 行（仅 1 个文件，+5 行）：

- 在 `int(id)` 之前显式判断 `id is None`
- 缺失 `sub` 时抛出与现有 token 错误一致的 `HTTPException(401)`

## 验证

写了 `/tmp/test_jwt_sub.py` 用 `unittest.mock.patch` 替换 `jose.jwt.decode`，让它返回一个不含 `sub` 的 payload，构造 `db.query(...).first()` 返回 `None` 的最小可复现场景。

- 父 commit（无修复）：`TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'` — bug 重现
- 本 commit：`HTTPException(status_code=401, detail={'code': 5000, 'message': 'Token Error', ...})` — bug 修复
- `python3 -m py_compile tm-backend/app/dependencies.py` 通过

## 影响

- 仅当客户端发送「签名正确但缺少 `sub` 声明」的 token 时触发；正常登录流程不受影响（`/login` 接口生成的 token 都包含 `sub`）
- 修复后此类异常输入统一返回 401，行为与现有 `JWTError` / `ValidationError` 分支一致
- 不改变其他路径的返回值语义

## 与已开 PR 的关系

- #122「JWT decode 的 algorithms 参数改为列表格式」— 不同的 JWT 配置问题，不重叠
- #49「JWT 验证添加用户不存在检查」— 关注 user lookup 结果，不覆盖 `int(None)` TypeError
- #93「token 判空使用严格等于运算符」— 前端 `base.ts` 严格等于，与本 PR 无关
- #135「dependencies.py except 子句 raise 添加 from e」— 关注 `from e` 异常链，与本 PR 互补