### PR TITLE
fix(config): save_configs 异常捕获补充 from e 异常链

### DIFF
--- a/tm-backend/app/routers/config.py
+++ b/tm-backend/app/routers/config.py
@@ -77,7 +77,7 @@ async def save_configs(
         }
     except Exception as e:
         db.rollback()
-        raise HTTPException(status_code=500, detail=f"保存失败: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"保存失败: {str(e)}") from e
 
 
 @router.get("/check-inactive")


### PR DESCRIPTION
补充 `config.py` 中 `save_configs` 异常捕获的 `from e` 异常链，与既有 PR #134 / #135 保持一致风格。

## 改动

`tm-backend/app/routers/config.py` 第 78 行：

```diff
 except Exception as e:
     db.rollback()
-    raise HTTPException(status_code=500, detail=f"保存失败: {str(e)}")
+    raise HTTPException(status_code=500, detail=f"保存失败: {str(e)}") from e
```

## 上下文

`save_configs` 在 DB commit 失败时会抛出 `HTTPException(500)`。如果不加 `from e`，异常链会被 Python 默认切断，调试时只能看到 `HTTPException`，看不到底层 `SQLAlchemyError` 的完整堆栈。

PR #134 已覆盖 `users.py` 的同类问题，PR #135 已覆盖 `dependencies.py` 和 `tutorial.py` 的同类问题。`config.py` 的这一处遗漏由本次 PR 补齐。

## 验证

`/tmp/test_config_b904.py`：
- [1] 源码存在 `from e` raise
- [2] AST 检测 `Raise` 节点带 `cause`
- [3] FastAPI TestClient 触发失败请求，响应 500 + 真实 detail
- [4] 直接调用 save_configs，`HTTPException.__cause__` 为底层 `RuntimeError`，异常链完整

git stash 三步舞：测试在 main 上失败、在 fix 分支上通过。

```
$ git stash && python3 /tmp/test_config_b904.py
AssertionError: fix not in source  ← 验证测试在 main 上失败

$ git stash pop && python3 /tmp/test_config_b904.py
All checks passed.  ← 验证测试在 fix 分支上通过
```

## 配套说明

- 单文件、单 commit、单行变更
- 不依赖任何新增 import
- 与 PR #134 / #135 同属 `from e` 异常链收尾系列
- 未触及任何其他文件、未改变对外行为（HTTPException status_code / detail 文案不变）