### PR TITLE
新增：课程列表展开状态持久化到 localStorage

### DIFF
--- a/tm-frontend/src/views/Courses.vue
+++ b/tm-frontend/src/views/Courses.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { fetchCoursesAPI } from '../request/tutorial/api'
 import { ElMessage } from 'element-plus'
@@ -29,6 +29,30 @@ const router = useRouter()
 const loading = ref(false)
 const courses = ref<Course[]>([])
 const expandedCourses = ref<Set<string>>(new Set())
+const EXPANDED_COURSES_KEY = 'courses-expanded-state'
+
+// 从 localStorage 恢复用户已展开的课程
+try {
+  const stored = localStorage.getItem(EXPANDED_COURSES_KEY)
+  if (stored) {
+    const parsed = JSON.parse(stored)
+    if (Array.isArray(parsed)) {
+      expandedCourses.value = new Set(parsed.filter((v): v is string => typeof v === 'string'))
+    }
+  }
+} catch (e) {
+  // localStorage 可能不可用或数据损坏，忽略并使用空集合
+  console.error('恢复已展开课程状态失败:', e)
+}
+
+// 监听变化并持久化到 localStorage
+watch(expandedCourses, (newSet) => {
+  try {
+    localStorage.setItem(EXPANDED_COURSES_KEY, JSON.stringify(Array.from(newSet)))
+  } catch (e) {
+    console.error('保存已展开课程状态失败:', e)
+  }
+}, { deep: true })
 
 const getCourseIcon = (name: string) => {
   const nameLower = name.toLowerCase()
@@ -90,8 +114,10 @@ const fetchCourses = async () => {
     const res = await fetchCoursesAPI()
     if (res.code === 200) {
       courses.value = res.data
-      // 默认展开前2个课程
-      courses.value.slice(0, 2).forEach(c => expandedCourses.value.add(c.path))
+      // 仅当用户没有任何已展开记录时，默认展开前2个课程
+      if (expandedCourses.value.size === 0) {
+        courses.value.slice(0, 2).forEach(c => expandedCourses.value.add(c.path))
+      }
     }
   } catch (error) {
     ElMessage.error('获取课程列表失败')


### PR DESCRIPTION
## 背景

`Courses.vue` 中的 `expandedCourses` 集合此前仅保存在内存中：
- 用户收起/展开某个课程后，刷新页面或重新进入页面，已展开的课程会回到默认的前2个状态
- 没有跨刷新保留用户选择的机制

## 修改内容

`tm-frontend/src/views/Courses.vue`：

1. 新增 `EXPANDED_COURSES_KEY` 常量（`'courses-expanded-state'`），命名空间隔离不影响其他缓存
2. 模块初始化时从 localStorage 恢复用户已展开的课程路径集合
3. 使用 `watch(expandedCourses, ..., { deep: true })` 深度监听变化，自动写回 localStorage
4. 类型守卫 `filter((v): v is string => typeof v === 'string')` 过滤非字符串值
5. try/catch 包裹读写，localStorage 不可用或数据损坏时静默降级到内存
6. `fetchCourses` 中默认展开前2个的逻辑改为仅在 `expandedCourses.size === 0` 时执行（保留用户选择）

## 行为变化

- 用户展开/收起某个课程后，状态会跨刷新保留
- 用户已有的展开选择优先于默认的前2个展开（首次访问除外）
- 多浏览器/隐私模式之间互不影响（localStorage 范围天然隔离）
- localStorage 异常（隐私模式、QuotaExceeded、数据损坏）不会阻断页面其他功能

## 验证

编写 Node mock localStorage 验证脚本，覆盖 6 个场景：

1. 首次打开（无 localStorage）→ 默认展开前2个，写入 localStorage
2. 用户收起某个课程 → localStorage 更新，刷新后状态保留
3. localStorage 损坏数据 → 静默降级为空集合
4. localStorage 中混入非字符串值 → 类型守卫过滤
5. localStorage 不可用 → 内存降级，异常不阻断页面
6. 已有用户选择 → 不被默认值覆盖

6 个场景全部通过。

## 与已有 PR 的关系

- 与 #108（课程列表页面添加搜索筛选功能）无冲突：本 PR 仅修改 `expandedCourses` 持久化，不涉及搜索功能
- 与 #109（学习计时器在浏览器标签页实时显示学习时长）无冲突：不同文件
- 与已合并的 #115（教程目录结构解析添加5分钟缓存）理念一致：客户端缓存体验优化

## 复现

```
# 复现步骤
1. 进入"课程中心"页面
2. 收起前2个默认展开的课程，仅展开第3个
3. 刷新页面
4. 观察：刷新后只展开第3个（修复前会回到默认的前2个）
```