### PR TITLE
新增：学习页面已完成课时进度持久化到 localStorage

### DIFF
--- a/tm-frontend/src/views/Study.vue
+++ b/tm-frontend/src/views/Study.vue
@@ -68,6 +68,30 @@ const timerInterval = ref<number | null>(null)
 const showReportDialog = ref(false)
 const reportDuration = ref(30)
 const completedLessons = ref<Set<string>>(new Set())
+const COMPLETED_LESSONS_KEY = 'study-completed-lessons'
+
+// 从 localStorage 恢复已完成的课时记录
+try {
+  const stored = localStorage.getItem(COMPLETED_LESSONS_KEY)
+  if (stored) {
+    const parsed = JSON.parse(stored)
+    if (Array.isArray(parsed)) {
+      completedLessons.value = new Set(parsed.filter((v): v is string => typeof v === 'string'))
+    }
+  }
+} catch (e) {
+  // localStorage 可能不可用或数据损坏，忽略并使用空集合
+  console.warn('恢复已完成课时记录失败:', e)
+}
+
+// 监听变化并持久化到 localStorage
+watch(completedLessons, (newSet) => {
+  try {
+    localStorage.setItem(COMPLETED_LESSONS_KEY, JSON.stringify(Array.from(newSet)))
+  } catch (e) {
+    console.warn('保存已完成课时记录失败:', e)
+  }
+}, { deep: true })
 
 // 代码块数据接口
 interface CodeBlockData {


### PR DESCRIPTION
## 背景

Study.vue 中的 completedLessons 集合此前仅保存在内存中：
- 用户完成一节课后，刷新页面或重新进入课程，已标记为已完成的课时记录会丢失
- 同一课程学习流程中需要重新标记已完成的课时

## 修改内容

tm-frontend/src/views/Study.vue：

1. 新增 COMPLETED_LESSONS_KEY 常量（'study-completed-lessons'），命名空间隔离不影响其他缓存
2. 模块初始化时从 localStorage 恢复已完成的课时路径集合
3. 使用 watch(completedLessons, ..., { deep: true }) 深度监听变化，自动写回 localStorage
4. 类型守卫 filter((v): v is string => typeof v === 'string') 过滤非字符串值
5. try/catch 包裹读写，localStorage 不可用或数据损坏时静默降级到内存
6. 复用 v1.72 PR #151 已确立的持久化模式：模块初始化恢复 + watch 深度监听 + 类型守卫 + 异常降级

## 行为变化

- 用户完成课时后，状态会跨刷新保留
- 多浏览器/隐私模式之间互不影响（localStorage 范围天然隔离）
- localStorage 异常（隐私模式、QuotaExceeded、数据损坏）不会阻断页面其他功能

## 验证

编写 Node mock localStorage 验证脚本（verify_study_localstorage.js），覆盖 6 个场景：

1. 首次打开（无 localStorage）→ 空集合，不写入
2. 用户完成一节课 → localStorage 更新，刷新后状态保留
3. localStorage 损坏数据 → 静默降级为空集合
4. localStorage 中混入非字符串值 → 类型守卫过滤
5. localStorage 不可用（throw on get）→ 内存降级，异常不阻断页面
6. QuotaExceeded on set → persist 失败，内存中 Set 仍保留新增项

6 个场景全部通过。

## 与已有 PR 的关系

- 与 #141（fix(study): 通过 sendBeacon 在页面离开时自动申报学习时长）无冲突：本 PR 修改的是客户端 completedLessons 状态持久化，#141 修改的是 sendBeacon 自动申报，文件位置不同
- 与 #109（学习计时器在浏览器标签页实时显示学习时长）无冲突：不同状态字段
- 与 #151（课程列表展开状态持久化到 localStorage）模式一致：本 PR 复用同样的持久化模式

## 复现

```
# 复现步骤
1. 进入"学习中心"，完成一节课（点击"完成学习"按钮）
2. 刷新页面，重新进入同一课程
3. 观察：刷新后已完成的课时仍然标记为已完成（修复前会回到全部未完成）
```
