### PR TITLE
新增：学习页面自动恢复上次打开的课时位置

### DIFF
--- a/tm-frontend/src/views/Study.vue
+++ b/tm-frontend/src/views/Study.vue
@@ -69,6 +69,9 @@ const showReportDialog = ref(false)
 const reportDuration = ref(30)
 const completedLessons = ref<Set<string>>(new Set())
 
+// 上次打开课时位置持久化键
+const LAST_LESSON_KEY = 'study-last-lesson'
+
 // 代码块数据接口
 interface CodeBlockData {
   id: string
@@ -93,7 +96,7 @@ const fetchCourse = async () => {
     if (res.code === 200) {
       course.value = res.data
 
-      // 如果有指定章节，跳转到章节第一课
+      // 如果有指定章节，跳转到章节第一课；否则恢复上次打开的课时
       const chapterName = route.query.chapter as string
       if (chapterName) {
         currentChapter.value = chapterName
@@ -102,6 +105,17 @@ const fetchCourse = async () => {
           const firstLesson = chapter.lessons[0]
           loadLesson(firstLesson.path, firstLesson.title, chapter.name)
         }
+      } else {
+        // 尝试恢复上次在该课程中的阅读位置
+        try {
+          const raw = localStorage.getItem(LAST_LESSON_KEY)
+          if (raw) {
+            const saved = JSON.parse(raw)
+            if (saved && saved.course === courseName && saved.path) {
+              loadLesson(saved.path, saved.title || '', saved.chapter || '')
+            }
+          }
+        } catch (e) { /* 静默降级到默认空状态 */ }
       }
     }
   } catch (error) {
@@ -151,6 +165,23 @@ const stopTimer = () => {
     timerInterval.value = null
   }
 }
+
+// 监听 currentPath 变化，自动保存当前课时位置到 localStorage
+watch(currentPath, (newPath) => {
+  try {
+    if (newPath) {
+      const courseName = route.query.course as string
+      localStorage.setItem(LAST_LESSON_KEY, JSON.stringify({
+        course: courseName,
+        path: newPath,
+        title: currentTitle.value,
+        chapter: currentChapter.value
+      }))
+    } else {
+      localStorage.removeItem(LAST_LESSON_KEY)
+    }
+  } catch (e) { /* 静默降级 */ }
+})
 
 // 格式化时间
 const formatTime = (seconds: number) => {


### PR DESCRIPTION
## 背景

Study.vue 中的 currentPath / currentTitle / currentChapter 仅保存在内存中：

- 用户在一门课程中阅读到第 N 节课后，刷新页面或重新进入同一课程（不带 chapter 查询参数），会回到默认空状态，需要重新手动点开课时
- 多次刷新同一课程体验差

## 修改内容

tm-frontend/src/views/Study.vue（+32/-1）：

1. 新增 `LAST_LESSON_KEY` 常量（`study-last-lesson`），命名空间隔离不影响其他缓存
2. `fetchCourse` 加载课程后，若 URL 无 chapter 查询参数，尝试从 localStorage 恢复上次阅读位置
3. 仅当保存的 course 名称与当前课程匹配时才恢复，防止跨课程误跳转
4. 使用 `watch(currentPath, ...)` 在路径变化时自动写回 localStorage
5. currentPath 置空时调用 `removeItem` 清空保存的位置
6. 复用 #151 / #152 已确立的持久化模式：try/catch 包裹读写，localStorage 不可用或数据损坏时静默降级

## 行为变化

- 用户在同一课程中阅读到第 N 节后，刷新页面或重新进入课程（不带 chapter 参数），会自动加载上次阅读位置
- 切换到不同课程时不会误恢复（course 名称不匹配）
- localStorage 异常（隐私模式 / QuotaExceeded / 数据损坏）不会阻断页面其他功能
- currentPath 被清空（兜底）时同步清除 localStorage

## 验证

编写 Node mock localStorage 验证脚本（`verify_study_last_lesson.js`），覆盖 9 个场景全部通过：

| # | 场景 | 结果 |
|---|------|------|
| 1 | 首次打开（无 localStorage）→ 不恢复 | PASS |
| 2 | 用户打开一节课 → localStorage 更新 | PASS |
| 3 | 刷新（重新进入同一课程）→ 恢复上次位置 | PASS |
| 4 | 不同课程名 → 不恢复（防止跨课程误跳转） | PASS |
| 5 | localStorage 损坏数据 → 静默降级 | PASS |
| 6 | localStorage 不可用（throw on get）→ 内存降级 | PASS |
| 7 | currentPath 置空 → removeItem 清空 | PASS |
| 8 | QuotaExceeded on set → 静默 | PASS |
| 9 | 无 chapter 参数 + 有保存路径 → 恢复 | PASS |

## 复现

```
# 复现步骤
1. 进入学习中心，选一门课程（如 TypeScript），点开一节课
2. 刷新页面，重新进入同一课程（不带 chapter 参数）
3. 观察：刷新后自动加载上次的课时（修复前需要重新手动点开）
```

## 与已有 PR 的关系

- 与 #152（学习页面已完成课时持久化）使用同一持久化模式但存储键与字段不同，无冲突
- 与 #141（sendBeacon 自动申报学习时长）作用位置不同，无冲突
- 与 #151（课程列表展开状态）持久化模式一致